### PR TITLE
fix: sets cdk-fragment version to general 2.11-SNAPSHOT version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -45,8 +45,8 @@ dependencies {
     implementation group: 'org.openscience.cdk', name: 'cdk-smiles', version: cdkVersion
     implementation group: 'org.openscience.cdk', name: 'cdk-standard', version: cdkVersion
     implementation group: 'org.openscience.cdk', name: 'cdk-valencycheck', version: cdkVersion
-    //specific CDK 2.11 snapshot release to get FunctionalGroupsFinder that also copies atomic charges
-    implementation group: 'org.openscience.cdk', name: 'cdk-fragment', version: '2.11-20250211.070243-7'
+    //CDK 2.11 snapshot release to get FunctionalGroupsFinder that also copies atomic charges
+    implementation group: 'org.openscience.cdk', name: 'cdk-fragment', version: '2.11-SNAPSHOT'
     implementation group: 'org.openscience.cdk', name: 'cdk-scaffold', version: '2.8'
     implementation group: 'com.github.librepdf', name: 'openpdf', version: '2.0.3'
     implementation group: 'org.openjfx', name: 'javafx-controls', version: javaFxVersion, classifier: 'win'


### PR DESCRIPTION
because specific snapshot releases are only availbale for a month, apparently.