### PR TITLE
Change macOS version in deployment workflow

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ macos-13 , macos-latest ]
+        os: [ macos-15-intel , macos-15 ] #the latter one is Arm64 architecture
         java: [ '21.0.1' ]
       fail-fast: false
     name: ${{ matrix.os }}


### PR DESCRIPTION
macos-13 (intel architecture) is deprecated, so replaced it with the new macos-15-intel; replaced macos-latest with explicit macos-15 (Arm64 architecture)