### PR TITLE
fix: DynamicSMILESFileReader now parses SMILES codes using the ChemUtil method

### DIFF
--- a/src/main/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReader.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReader.java
@@ -34,8 +34,6 @@ import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
-import org.openscience.cdk.interfaces.IChemObjectBuilder;
-import org.openscience.cdk.silent.SilentChemObjectBuilder;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -133,9 +131,8 @@ public class DynamicSMILESFileReader {
                 FileReader tmpSmilesFileReader = new FileReader(aFile);
                 BufferedReader tmpSmilesFileBufferedReader = new BufferedReader(tmpSmilesFileReader, BasicDefinitions.BUFFER_SIZE)
         ) {
-            IChemObjectBuilder tmpBuilder = SilentChemObjectBuilder.getInstance();
             // AtomContainer to save the parsed SMILES in
-            IAtomContainer tmpMolecule = tmpBuilder.newAtomContainer();
+            IAtomContainer tmpMolecule = null;
             String tmpSmilesFileDeterminedSeparator = String.valueOf(DynamicSMILESFileFormat.PLACEHOLDER_SEPARATOR_CHAR);
             int tmpSmilesCodeExpectedPosition = DynamicSMILESFileFormat.DEFAULT_SMILES_COLUMN_POSITION;
             int tmpIDExpectedPosition = DynamicSMILESFileFormat.PLACEHOLDER_ID_COLUMN_POSITION;
@@ -167,7 +164,7 @@ public class DynamicSMILESFileReader {
                             //if it fails again, goes to catch block below
                             tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileCurrentLine.trim(), false, false);
                         }
-                        if (!tmpMolecule.isEmpty()) {
+                        if (tmpMolecule != null && !tmpMolecule.isEmpty()) {
                             //success, SMILES column is identified
                             tmpSmilesCodeExpectedPosition = 0;
                             break findSeparatorLoop;
@@ -199,7 +196,7 @@ public class DynamicSMILESFileReader {
                                 //if it fails again, goes to catch block below
                                 tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpNextElementOfLine.trim(), false, false);
                             }
-                            if (!tmpMolecule.isEmpty()) {
+                            if (tmpMolecule != null && !tmpMolecule.isEmpty()) {
                                 //success, separator and SMILES column are identified
                                 tmpSmilesFileDeterminedSeparator = tmpSeparator;
                                 tmpSmilesCodeExpectedPosition = i;
@@ -216,7 +213,7 @@ public class DynamicSMILESFileReader {
                     }
                 }
             }
-            if (tmpMolecule.isEmpty()) {
+            if (tmpMolecule == null || tmpMolecule.isEmpty()) {
                 throw new IOException("Chosen file does not fit to the expected format of a SMILES file.");
             }
             boolean tmpHasHeaderLine;

--- a/src/main/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReader.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReader.java
@@ -26,15 +26,16 @@
 package de.unijena.cheminf.mortar.model.io;
 
 import de.unijena.cheminf.mortar.model.util.BasicDefinitions;
+import de.unijena.cheminf.mortar.model.util.ChemUtil;
 import de.unijena.cheminf.mortar.model.util.FileUtil;
 
 import org.openscience.cdk.AtomContainerSet;
+import org.openscience.cdk.exception.CDKException;
 import org.openscience.cdk.exception.InvalidSmilesException;
 import org.openscience.cdk.interfaces.IAtomContainer;
 import org.openscience.cdk.interfaces.IAtomContainerSet;
 import org.openscience.cdk.interfaces.IChemObjectBuilder;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
-import org.openscience.cdk.smiles.SmilesParser;
 
 import java.io.BufferedReader;
 import java.io.File;
@@ -135,7 +136,6 @@ public class DynamicSMILESFileReader {
             IChemObjectBuilder tmpBuilder = SilentChemObjectBuilder.getInstance();
             // AtomContainer to save the parsed SMILES in
             IAtomContainer tmpMolecule = tmpBuilder.newAtomContainer();
-            SmilesParser tmpSmilesParser = new SmilesParser(tmpBuilder);
             String tmpSmilesFileDeterminedSeparator = String.valueOf(DynamicSMILESFileFormat.PLACEHOLDER_SEPARATOR_CHAR);
             int tmpSmilesCodeExpectedPosition = DynamicSMILESFileFormat.DEFAULT_SMILES_COLUMN_POSITION;
             int tmpIDExpectedPosition = DynamicSMILESFileFormat.PLACEHOLDER_ID_COLUMN_POSITION;
@@ -159,15 +159,20 @@ public class DynamicSMILESFileReader {
                         && DynamicSMILESFileReader.containsOnlySMILESValidCharacters(tmpSmilesFileCurrentLine)
                         && !DynamicSMILESFileReader.PARSABLE_SMILES_EXCEPTIONS.contains(tmpSmilesFileCurrentLine.trim())) {
                     try {
-                        //if parsing fails goes to catch block below
-                        // trimmed because a leading whitespace followed by a character string are interpreted as an empty structure and its name
-                        tmpMolecule = tmpSmilesParser.parseSmiles(tmpSmilesFileCurrentLine.trim());
+                        try{
+                            //if parsing fails goes to catch block below
+                            //trimmed because a leading whitespace followed by a character string are interpreted as an empty structure and its name
+                            tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileCurrentLine.trim(), true, false);
+                        } catch (CDKException aCdkException){
+                            //if it fails again, goes to catch block below
+                            tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileCurrentLine.trim(), false, false);
+                        }
                         if (!tmpMolecule.isEmpty()) {
                             //success, SMILES column is identified
                             tmpSmilesCodeExpectedPosition = 0;
                             break findSeparatorLoop;
                         }
-                    } catch (InvalidSmilesException anException) {
+                    } catch (CDKException anException) {
                         // do nothing, continue with splitting the line using different separators
                     }
                 }
@@ -186,8 +191,14 @@ public class DynamicSMILESFileReader {
                             break; //... try next separator
                         }
                         try {
-                            //if parsing fails goes to catch block below
-                            tmpMolecule = tmpSmilesParser.parseSmiles(tmpNextElementOfLine.trim());
+                            try{
+                                //if parsing fails goes to catch block below
+                                //trimmed because a leading whitespace followed by a character string are interpreted as an empty structure and its name
+                                tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpNextElementOfLine.trim(), true, false);
+                            } catch (CDKException aCdkException){
+                                //if it fails again, goes to catch block below
+                                tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpNextElementOfLine.trim(), false, false);
+                            }
                             if (!tmpMolecule.isEmpty()) {
                                 //success, separator and SMILES column are identified
                                 tmpSmilesFileDeterminedSeparator = tmpSeparator;
@@ -199,7 +210,7 @@ public class DynamicSMILESFileReader {
                             } //else {
                                 // continue to try next element in row
                             //}
-                        } catch (InvalidSmilesException anException) {
+                        } catch (CDKException anException) {
                             // continue to try next element in row
                         }
                     }
@@ -211,12 +222,26 @@ public class DynamicSMILESFileReader {
             boolean tmpHasHeaderLine;
             try {
                 if (tmpIDExpectedPosition == -1) {
-                    tmpSmilesParser.parseSmiles(tmpSmilesFileFirstLine.trim());
+                    try{
+                        //if parsing fails goes to catch block below
+                        ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileFirstLine.trim(), true, false);
+                    } catch (CDKException aCdkException){
+                        //if it fails again, goes to catch block below
+                        ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileFirstLine.trim(), false, false);
+                    }
                 } else {
-                    tmpSmilesParser.parseSmiles(tmpSmilesFileFirstLine.trim().split(tmpSmilesFileDeterminedSeparator, 3)[tmpSmilesCodeExpectedPosition]);
+                    try{
+                        //if parsing fails goes to catch block below
+                        ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileFirstLine.trim().split(tmpSmilesFileDeterminedSeparator, 3)[tmpSmilesCodeExpectedPosition],
+                                true, false);
+                    } catch (CDKException aCdkException){
+                        //if it fails again, goes to catch block below
+                        ChemUtil.parseSmilesToAtomContainer(tmpSmilesFileFirstLine.trim().split(tmpSmilesFileDeterminedSeparator, 3)[tmpSmilesCodeExpectedPosition],
+                                false, false);
+                    }
                 }
                 tmpHasHeaderLine = false;
-            } catch (InvalidSmilesException anException) {
+            } catch (CDKException anException) {
                 tmpHasHeaderLine = true;
             }
             return new DynamicSMILESFileFormat(tmpHasHeaderLine, tmpSmilesFileDeterminedSeparator.charAt(0), tmpSmilesCodeExpectedPosition, tmpIDExpectedPosition);
@@ -248,10 +273,8 @@ public class DynamicSMILESFileReader {
                 BufferedReader tmpSmilesFileBufferedReader = new BufferedReader(tmpSmilesFileReader, BasicDefinitions.BUFFER_SIZE)
         ) {
             IAtomContainerSet tmpAtomContainerSet = new AtomContainerSet();
-            IChemObjectBuilder tmpBuilder = SilentChemObjectBuilder.getInstance();
             // AtomContainer to save the parsed SMILES in
             IAtomContainer tmpMolecule;
-            SmilesParser tmpSmilesParser = new SmilesParser(tmpBuilder);
             String tmpSmilesFileCurrentLine;
             String tmpSmilesFileDeterminedSeparator = aFormat.getSeparatorChar().toString();
             String[] tmpProcessedLineArray = new String[0];
@@ -276,12 +299,18 @@ public class DynamicSMILESFileReader {
                         tmpSmiles = tmpSmilesFileCurrentLine.trim();
                     }
                     if (tmpSmiles != null && !tmpSmiles.isEmpty()) {
-                        //throws exception if SMILES string is null, goes to catch block
-                        tmpMolecule = tmpSmilesParser.parseSmiles(tmpSmiles);
+                        try{
+                            //throws exception if SMILES string is null, goes to catch block down below
+                            tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmiles, true, false);
+                        } catch (CDKException aCdkException){
+                            //if it fails again, goes to catch block below
+                            tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmiles, false, false);
+                        }
                     } else {
                         throw new InvalidSmilesException("String is empty");
                     }
-                } catch (InvalidSmilesException | IndexOutOfBoundsException | NullPointerException anException) {
+                } catch (CDKException | IndexOutOfBoundsException | NullPointerException anException) {
+                    //also catches InvalidSmilesException, since it's a subclass of CDKException
                     this.skippedLinesCounter++;
                     DynamicSMILESFileReader.LOGGER.log(Level.WARNING, String.format("Import failed for structure in line (starting at 0):\t%s", tmpLineInFileCounter));
                     continue;

--- a/src/test/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReaderTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/io/DynamicSMILESFileReaderTest.java
@@ -365,4 +365,28 @@ public class DynamicSMILESFileReaderTest {
         Assertions.assertEquals("cmnpd_id_11687", tmpMolSet.getAtomContainer(36).getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY));
         Assertions.assertEquals(0, tmpReader.getSkippedLinesCounter());
     }
+    //
+    /**
+     * Tests a file with aromatic fragments created using the Ertl algorithm fragmenter.
+     * Test file's specifications:
+     * - 10 structures
+     * - no headline
+     * - no faulty lines
+     * - SMILES first in line, name second
+     * - used separator: space
+     *
+     * @throws Exception if anything goes wrong
+     */
+    @Test
+    public void testAromatics() throws Exception {
+        URL tmpURL = this.getClass().getResource("Aromatics.smi");
+        File tmpResourceFile = Paths.get(tmpURL.toURI()).toFile();
+        DynamicSMILESFileFormat tmpFormat = DynamicSMILESFileReader.detectFormat(tmpResourceFile);
+        DynamicSMILESFileReader tmpReader = new DynamicSMILESFileReader();
+        IAtomContainerSet tmpMolSet = tmpReader.readFile(tmpResourceFile, tmpFormat);
+        Assertions.assertEquals(10, tmpMolSet.getAtomContainerCount());
+        Assertions.assertEquals("derivat-(1S)-6,8-dihydroxy-1-methyl-1,2-dihydrocyclopenta[c]isochromene-3,5-dione", tmpMolSet.getAtomContainer(0).getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY));
+        Assertions.assertEquals("derivat-6-chloro-3-(3-methylisoxazol-5-yl)-4-phenylquinolin-2(1H)-one", tmpMolSet.getAtomContainer(9).getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY));
+        Assertions.assertEquals(0, tmpReader.getSkippedLinesCounter());
+    }
 }

--- a/src/test/resources/de/unijena/cheminf/mortar/model/io/Aromatics.smi
+++ b/src/test/resources/de/unijena/cheminf/mortar/model/io/Aromatics.smi
@@ -1,0 +1,10 @@
+cc(-cccC)c(c1ccccc1)-c2ccccc2 derivat-(1S)-6,8-dihydroxy-1-methyl-1,2-dihydrocyclopenta[c]isochromene-3,5-dione
+cccccCc1cc2ccccc2cc1cccC derivat-Germicidin O
+c1ccc(c(cc1)C(C)C)CCC(C)C derivat-amlexanox
+cccc(c)[C@@H]1[C@@H](C)C[C@H](C)C[C@@H](C)[C@@H]1C derivat-8,10-dihydroxy-5-[(6-hydroxy-4-oxopyran-2-yl)methyl]-2-methylbenzo[h]chromen-4-one
+C[C@@H](C)c(c)c1ccccc1c derivat-Nookatinol
+cccc(c)CCCCCCCCCCCCCCCC(C)C derivat-8-methyl-10-oxo-2,3,5,6-tetrahydro-1h,4h,10h-11-oxa-3a-aza-benzo[de]anthracene-9-carbaldehyde
+CC[C@@H](C)cc(C)cc(c)C derivat-2-Amino-3-ethyl-9H-pyrido(2,3-b)indole
+cccc(c)cc1cccc(c1)C(C)C derivat-4-Hydroxy-3-(16-methylheptadecyl)-2H-pyran-2-one
+cc(cc(c)CC)c1ccccc1 derivat-Hypocrellutin A
+ccc(c1cc(cc(c1)CCC)CCC)C derivat-6-chloro-3-(3-methylisoxazol-5-yl)-4-phenylquinolin-2(1H)-one


### PR DESCRIPTION
This pull request refactors the SMILES parsing logic in `DynamicSMILESFileReader` to use the utility method from `ChemUtil`, improving robustness and handling of aromatic SMILES fragments. It also adds a new unit test for files containing aromatic fragments.

**Refactoring and Robustness Improvements:**

* Replaced direct usage of `SmilesParser` with the `ChemUtil.parseSmilesToAtomContainer` method throughout `DynamicSMILESFileReader`, allowing for more flexible and robust SMILES parsing, including fallback parsing strategies. [[1]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bR29-L37) [[2]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bL138) [[3]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bR161-R175) [[4]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bR193-R201) [[5]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bL214-R244) [[6]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bL251-L254) [[7]](diffhunk://#diff-1e002f2e4a971270c93218a8e0b5705d426d885f547ec745fd4408055cecba6bL279-R313)

**Testing Enhancements:**

* Added a new test case `testAromatics` in `DynamicSMILESFileReaderTest` to verify correct import of files with aromatic fragments, using a new test resource file `Aromatics.smi`. [[1]](diffhunk://#diff-acf9d1d53ef18e3fb8fe62527ec6c73fd0c3c924ea5109a6f4cd165769048d9cR368-R391) [[2]](diffhunk://#diff-aff17b5cf833eb5a28bd4f813f085c33a217321030b8969b05c38cb586eb7d01R1-R10)