### PR TITLE
feat: adds routine for fixing molecules that cannot be kekulized because an aromatic N is missing a hydrogen atom; empty molecules are no longer imported

### DIFF
--- a/src/main/java/de/unijena/cheminf/mortar/model/io/Importer.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/io/Importer.java
@@ -280,7 +280,7 @@ public class Importer {
         for (IAtomContainer tmpAtomContainer : anAtomContainerSet.atomContainers()) {
             //returns null if no SMILES code could be created
             String tmpSmiles = ChemUtil.createUniqueSmiles(tmpAtomContainer, isRegardStereo);
-            if (tmpSmiles == null) {
+            if (tmpSmiles == null || tmpSmiles.isBlank()) {
                 tmpExceptionCount++;
                 continue;
             }
@@ -297,7 +297,7 @@ public class Importer {
         Importer.LOGGER.log(Level.INFO, () -> String.format("Successfully imported %d molecules from file: %s; " +
                 "%d molecules could not be parsed into the internal data model (SMILES code generation failed). " +
                 "See above how many molecules could not be read from the input file at all or produced exceptions while preprocessing.",
-                anAtomContainerSet.getAtomContainerCount(), this.getFileName(), finalTmpExceptionCount));
+                anAtomContainerSet.getAtomContainerCount() - finalTmpExceptionCount, this.getFileName(), finalTmpExceptionCount));
         return tmpReturnList;
     }
     //

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -75,7 +75,7 @@ public final class ChemUtil {
     /**
      * Pattern to match both 'n' and '[nH]' in SMILES (but not 'n' in Rn, Sn, In, Cn, Zn, Mn)
      */
-    public static String AROMATIC_N_REGEX = "\\[nH]|(?<!\\[[RSICZM])n";
+    public static final String AROMATIC_N_REGEX = "\\[nH]|(?<!\\[[RSICZM])n";
     //</editor-fold>
     //
     //<editor-fold defaultstate="collapsed" desc="Private static final class constants">

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -509,11 +509,6 @@ public final class ChemUtil {
         int tmpNrOfTotalCombinations = Math.min((int) Math.pow(2, tmpNCount), ChemUtil.MAX_TAUTOMER_COMBINATIONS);
         tautomerLoop:
         for (int i = 0; i < tmpNrOfTotalCombinations; i++) {
-            if (i >= ChemUtil.MAX_TAUTOMER_COMBINATIONS) {
-                ChemUtil.LOGGER.log(Level.INFO, "Generated 1,000 tautomers of molecule {0} and none were valid, so aborting",
-                        (String) aMolecule.getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY));
-                return null;
-            }
             StringBuilder tmpTautomerBuilder = new StringBuilder(tmpSmiles);
             int tmpOffset = 0;
             for (int j = 0; j < tmpNCount; j++) {

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -469,7 +469,7 @@ public final class ChemUtil {
         if (aMolecule.isEmpty()) {
             return null;
         }
-        //count aromatic nitrogen atoms to chose appropriate initial collection sizes below
+        //count aromatic nitrogen atoms to choose appropriate initial collection sizes below and reject molecules without any
         int tmpAromaticNCount = 0;
         for (IAtom tmpAtom : aMolecule.atoms()) {
             if (tmpAtom.getAtomicNumber().equals(IElement.N) && tmpAtom.isAromatic()) {
@@ -506,10 +506,10 @@ public final class ChemUtil {
         tmpSmiPar.kekulise(true);
         // Generate all 2^n combinations but already validate while generating and return the first valid solution
         int tmpNCount = tmpAromaticNPositions.size();
-        int tmpNrOfTotalCombinations = (int) Math.pow(2, tmpNCount);
+        int tmpNrOfTotalCombinations = Math.min((int) Math.pow(2, tmpNCount), ChemUtil.MAX_TAUTOMER_COMBINATIONS);
         tautomerLoop:
         for (int i = 0; i < tmpNrOfTotalCombinations; i++) {
-            if (i > ChemUtil.MAX_TAUTOMER_COMBINATIONS) {
+            if (i >= ChemUtil.MAX_TAUTOMER_COMBINATIONS) {
                 ChemUtil.LOGGER.log(Level.INFO, "Generated 1,000 tautomers of molecule {0} and none were valid, so aborting",
                         (String) aMolecule.getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY));
                 return null;

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -39,6 +39,8 @@ import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.regex.Pattern;
 
 /**
@@ -97,7 +99,7 @@ class ChemUtilTest {
         SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
         Assertions.assertEquals("N=C1N=C2C3=C(N1)CCC3CC(C)C2CCCC", smiGen.create(tmpMolecule));
     }
-    //CC(=O)O[Sn](C1=CC=CC=C1)(C2=CC=CC=C2)C3=CC=CC=C3
+    //
     /**
      * Makes sure that the Regex pattern in ChemUtil.fixAromaticNitrogenAndCreateSMILES() does not match 'n' in '[Sn]'.
      */
@@ -105,7 +107,7 @@ class ChemUtilTest {
     public void testFixAromaticNitrogenAndCreateSMILESPattern() throws Exception {
         //PubChem CID	16682804
         String tmpSmiles = "CC(=O)O[Sn](C1=CC=CC=C1)(C2=CC=CC=C2)C3=CC=CC=C3";
-        Pattern tmpNPattern = Pattern.compile("\\[nH]|(?<!\\[[RSICZM])n");
+        Pattern tmpNPattern = Pattern.compile(ChemUtil.AROMATIC_N_REGEX);
         Assertions.assertFalse(tmpNPattern.matcher(tmpSmiles).find());
     }
     //
@@ -156,5 +158,51 @@ class ChemUtilTest {
         tmpSmiPar.kekulise(true);
         Assertions.assertDoesNotThrow(() -> tmpSmiPar.parseSmiles(tmpFixedSmiles));
         Assertions.assertEquals("C[n+]1cn([C@@H]2O[C@H](CO)[C@@H](O)[C@H]2O)c3[nH]c(N)nc(=O)c31", tmpFixedSmiles);
+    }
+    //
+    /**
+     * Tests fixing a molecule imported from an aromatic SMILES string that is missing an explicit H on an aromatic N
+     * based on a bulk of ChEBI molecules with this issue.
+     */
+    @Test
+    public void testFixAromaticNitrogenAndCreateSMILESBulk() throws Exception {
+        String tmpChEBISmiles = """
+                CHEBI:10048	O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1
+                CHEBI:10049	O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1
+                CHEBI:10110	Cc1cn([C@H]2C[C@H](N=[N+]=[N-])[C@@H](CO)O2)c(=O)nc1=O
+                CHEBI:102257	Cc1nn([C@H]2C[C@H](O)[C@@H](COP(=O)(O)O)O2)c(=O)nc1=O
+                CHEBI:102485	O=C(O)c1cn([C@H]2C[C@H](O)[C@@H](CO)O2)c(=O)nc1=O
+                CHEBI:102517	O=C(O)c1cn([C@H]2C[C@H](O)[C@@H](COP(=O)(O)O)O2)c(=O)nc1=O
+                CHEBI:10502	Cc1cn([C@H]2C[C@H](O)[C@@H](COP(=O)(O)OP(=O)(O)O[C@H]3O[C@H](C)C[C@H](N)[C@H]3O)O2)c(=O)nc1=O
+                CHEBI:10525	Cc1cn([C@H]2C[C@H](O)[C@@H](COP(=O)(O)OP(=O)(O)O[C@@H]3C[C@@](C)(O)[C@@H](O)[C@H](C)O3)O2)c(=O)nc1=O
+                CHEBI:111511	O=c1nc(=O)n([C@H]2C[C@H](O)[C@@H](COP(=O)(O)O)O2)cc1CO[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O
+                CHEBI:111513	O=c1nc(=O)n([C@H]2C[C@H](O)[C@@H](CO)O2)cc1CO[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O
+                CHEBI:11515	[H]C(=O)Nc1c(N[C@@H]2O[C@H](COP(=O)(O)O)[C@@H](O)[C@H]2O)nc(N)nc1=O
+                CHEBI:115218	O=C(O)CNCc1cn([C@@H]2O[C@H](COP(=O)(O)O)[C@@H](O)[C@H]2O)c(=S)nc1=O
+                CHEBI:131188	Nc1ncnc2c([C@@H]3O[C@@H]4COP(=O)(O)O[C@H]4[C@H]3O)nnc12
+                CHEBI:131522	CN[C@H]1CC[C@@H](OP(=O)(O)OP(=O)(O)OC[C@H]2O[C@@H](n3cc(C)c(=O)nc3=O)C[C@@H]2O)O[C@@H]1C
+                CHEBI:131566	Nc1ncnc2c1ncn2[C@@H]1O[C@H](COP(=O)(O)O)[C@@H](OC(=O)[C@@H](N)Cc2cncn2)[C@H]1O
+                CHEBI:131575	Nc1ncnc2c1ncn2[C@@H]1O[C@H](COP(=O)(O)O)[C@@H](OC(=O)[C@@H](N)Cc2cnc3ccccc23)[C@H]1O
+                CHEBI:131580	Cc1nn([C@H]2C[C@H](O)[C@@H](CO)O2)c(=O)nc1=O
+                CHEBI:131616	Nc1nc(=O)ncc1CO[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O
+                CHEBI:131828	[H][C@]12O[C@H](C[C@@H]1O)n1c(nc3c(=O)nc(N)nc31)[C@H]2O
+                CHEBI:131829	[H][C@]12O[C@H](C[C@@H]1O)n1c(nc3c(=O)nc(N)nc31)[C@H]2OP(=O)(O)O
+                """;
+        SmilesParser tmpSmipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        tmpSmipar.kekulise(false);
+        List<String> tmpFailedMols = new ArrayList<>(10);
+        for (String tmpLine : tmpChEBISmiles.split("\n")) {
+            String tmpFixedSmilesString = ChemUtil.fixAromaticNitrogenAndCreateSMILES(tmpSmipar.parseSmiles(tmpLine.split("\t")[1]));
+            if (tmpFixedSmilesString == null) {
+                tmpFailedMols.add(tmpLine);
+            }
+        }
+        if (!tmpFailedMols.isEmpty()) {
+            System.out.println("Failed:");
+            for (String tmpLine : tmpFailedMols) {
+                System.out.println(tmpLine);
+            }
+            Assertions.fail();
+        }
     }
 }

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -32,6 +32,7 @@ import org.openscience.cdk.io.MDLV2000Reader;
 import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.smiles.SmilesGenerator;
+import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 
 import java.io.File;
@@ -79,6 +80,7 @@ class ChemUtilTest {
             Assertions.assertEquals(tmpSmilesCode, tmpSmilesCodeOutput);
         }
     }
+    //
     /**
      * Test importing a MOL file containing a molecule with radicals and verifying that these are fixed correctly.
      */
@@ -93,5 +95,21 @@ class ChemUtilTest {
         ChemUtil.fixRadicals(tmpMolecule);
         SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
         Assertions.assertEquals("N=C1N=C2C3=C(N1)CCC3CC(C)C2CCCC", smiGen.create(tmpMolecule));
+    }
+    //
+    /**
+     * Tests fixing a molecule imported from an aromatic SMILES string that is missing an explicit H on an aromatic N.
+     */
+    @Test
+    public void testFixAromaticNitrogenAndCreateSMILES() throws Exception {
+        //CHEBI:929
+        String tmpSmilesCode = "Nc1nc(N[C@@H]2O[C@H](COP(=O)(O)OP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]2O)c(N)c(=O)n1";
+        SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        tmpSmiPar.kekulise(false);
+        IAtomContainer tmpMolecule = tmpSmiPar.parseSmiles(tmpSmilesCode);
+        String tmpFixedSmiles = ChemUtil.fixAromaticNitrogenAndCreateSMILES(tmpMolecule);
+        Assertions.assertNotNull(tmpFixedSmiles);
+        tmpSmiPar.kekulise(true);
+        Assertions.assertDoesNotThrow(() -> tmpSmiPar.parseSmiles(tmpFixedSmiles));
     }
 }

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -39,6 +39,7 @@ import java.io.File;
 import java.io.FileReader;
 import java.net.URL;
 import java.nio.file.Paths;
+import java.util.regex.Pattern;
 
 /**
  * Tests for the utility functions in ChemUtil.
@@ -95,6 +96,17 @@ class ChemUtilTest {
         ChemUtil.fixRadicals(tmpMolecule);
         SmilesGenerator smiGen = new SmilesGenerator(SmiFlavor.Canonical);
         Assertions.assertEquals("N=C1N=C2C3=C(N1)CCC3CC(C)C2CCCC", smiGen.create(tmpMolecule));
+    }
+    //CC(=O)O[Sn](C1=CC=CC=C1)(C2=CC=CC=C2)C3=CC=CC=C3
+    /**
+     * Makes sure that the Regex pattern in ChemUtil.fixAromaticNitrogenAndCreateSMILES() does not match 'n' in '[Sn]'.
+     */
+    @Test
+    public void testFixAromaticNitrogenAndCreateSMILESPattern() throws Exception {
+        //PubChem CID	16682804
+        String tmpSmiles = "CC(=O)O[Sn](C1=CC=CC=C1)(C2=CC=CC=C2)C3=CC=CC=C3";
+        Pattern tmpNPattern = Pattern.compile("\\[nH]|(?<!\\[[RSICZM])n");
+        Assertions.assertFalse(tmpNPattern.matcher(tmpSmiles).find());
     }
     //
     /**

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -102,7 +102,7 @@ class ChemUtilTest {
      */
     @Test
     public void testFixAromaticNitrogenAndCreateSMILES() throws Exception {
-        //CHEBI:929
+        //CHEBI:929 - one n needs to be fixed
         String tmpSmilesCode = "Nc1nc(N[C@@H]2O[C@H](COP(=O)(O)OP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]2O)c(N)c(=O)n1";
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         tmpSmiPar.kekulise(false);
@@ -111,5 +111,38 @@ class ChemUtilTest {
         Assertions.assertNotNull(tmpFixedSmiles);
         tmpSmiPar.kekulise(true);
         Assertions.assertDoesNotThrow(() -> tmpSmiPar.parseSmiles(tmpFixedSmiles));
+    }
+    //
+    /**
+     * Tests fixing a molecule imported from an aromatic SMILES string that is missing explicit Hs on multiple aromatic N.
+     */
+    @Test
+    public void testFixAromaticNitrogensAndCreateSMILES() throws Exception {
+        //CHEBI:10048 - two n need to be fixed (without creating an uncharged(!) tetravalent N)
+        String tmpSmilesCode = "O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1";
+        SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        tmpSmiPar.kekulise(false);
+        IAtomContainer tmpMolecule = tmpSmiPar.parseSmiles(tmpSmilesCode);
+        String tmpFixedSmiles = ChemUtil.fixAromaticNitrogenAndCreateSMILES(tmpMolecule);
+        Assertions.assertNotNull(tmpFixedSmiles);
+        tmpSmiPar.kekulise(true);
+        Assertions.assertDoesNotThrow(() -> tmpSmiPar.parseSmiles(tmpFixedSmiles));
+    }
+    //
+    /**
+     * Tests fixing a molecule imported from an aromatic SMILES string that is missing an explicit H on a charged aromatic N.
+     */
+    @Test
+    public void testFixAromaticChargedNitrogenAndCreateSMILES() throws Exception {
+        //CHEBI:20794 - one aromatic n is charged and therefore needs to be tetravalent in the solution
+        String tmpSmilesCode = "C[n+]1cn([C@@H]2O[C@H](CO)[C@@H](O)[C@H]2O)c2nc(N)nc(=O)c21";
+        SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
+        tmpSmiPar.kekulise(false);
+        IAtomContainer tmpMolecule = tmpSmiPar.parseSmiles(tmpSmilesCode);
+        String tmpFixedSmiles = ChemUtil.fixAromaticNitrogenAndCreateSMILES(tmpMolecule);
+        Assertions.assertNotNull(tmpFixedSmiles);
+        tmpSmiPar.kekulise(true);
+        Assertions.assertDoesNotThrow(() -> tmpSmiPar.parseSmiles(tmpFixedSmiles));
+        Assertions.assertEquals("C[n+]1cn([C@@H]2O[C@H](CO)[C@@H](O)[C@H]2O)c3[nH]c(N)nc(=O)c31", tmpFixedSmiles);
     }
 }

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -186,8 +186,7 @@ class ChemUtilTest {
                 CHEBI:131580	Cc1nn([C@H]2C[C@H](O)[C@@H](CO)O2)c(=O)nc1=O
                 CHEBI:131616	Nc1nc(=O)ncc1CO[C@@H]1O[C@H](CO)[C@@H](O)[C@H](O)[C@H]1O
                 CHEBI:131828	[H][C@]12O[C@H](C[C@@H]1O)n1c(nc3c(=O)nc(N)nc31)[C@H]2O
-                CHEBI:131829	[H][C@]12O[C@H](C[C@@H]1O)n1c(nc3c(=O)nc(N)nc31)[C@H]2OP(=O)(O)O
-                """;
+                CHEBI:131829	[H][C@]12O[C@H](C[C@@H]1O)n1c(nc3c(=O)nc(N)nc31)[C@H]2OP(=O)(O)O""";
         SmilesParser tmpSmipar = new SmilesParser(SilentChemObjectBuilder.getInstance());
         tmpSmipar.kekulise(false);
         List<String> tmpFailedMols = new ArrayList<>(10);

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -197,11 +197,11 @@ class ChemUtilTest {
             }
         }
         if (!tmpFailedMols.isEmpty()) {
-            System.out.println("Failed:");
+            StringBuilder failMsg = new StringBuilder("Failed molecules:\n");
             for (String tmpLine : tmpFailedMols) {
-                System.out.println(tmpLine);
+                failMsg.append(tmpLine).append('\n');
             }
-            Assertions.fail();
+            Assertions.fail(failMsg.toString());
         }
     }
 }


### PR DESCRIPTION
This pull request improves the robustness of SMILES code generation and molecule import by handling cases where aromatic nitrogen atoms lack explicit hydrogens, which previously caused failures in parsing and kekulization. The changes introduce a new utility method to fix these molecules, update the import logic to use this fix, and add tests to ensure correct behavior.

**SMILES Generation and Import Robustness**
* Added `ChemUtil.fixAromaticNitrogenAndCreateSMILES`, which attempts to fix molecules with aromatic nitrogen atoms missing explicit hydrogens by generating all possible `[nH]`/`n` combinations and validating them. This allows successful parsing and SMILES generation for previously problematic molecules.
* Updated `ChemUtil.createUniqueSmiles` to use the new fix method when SMILES generation fails due to kekulization errors, improving the success rate of molecule imports.
* Modified the molecule import logic in `Importer.java` to treat blank SMILES codes as failures, and improved logging to accurately report the number of successfully imported molecules. [[1]](diffhunk://#diff-a4722b490363150b295a139b470ba9732cf8c8f12774be611d55940cf2238e5aL283-R283) [[2]](diffhunk://#diff-a4722b490363150b295a139b470ba9732cf8c8f12774be611d55940cf2238e5aL300-R300)

**Testing Improvements**
* Added a new test case in `ChemUtilTest.java` to verify that the fix for aromatic nitrogen works as intended, ensuring that the fixed SMILES can be parsed with kekulization enabled.