### PR TITLE
Finalisation of MolWURCS integration

### DIFF
--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/algorithm/MolWURCSFragmenter.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/algorithm/MolWURCSFragmenter.java
@@ -60,7 +60,7 @@ import java.util.logging.Logger;
  * available in MORTAR, using the <a href="https://doi.org/10.1007/s00216-024-05508-1">MolWURCS</a>
  * implementation of the identifier.
  * Note: we are not giving the option (via a setting) to validate ("double-check") the generated WURCS string
- * in side the WURCSWriter because we are anyway retranslating the generated WURCS string back into a molecule.
+ * inside the WURCSWriter because we are anyway retranslating the generated WURCS string back into a molecule.
  * The "double-check" routine of WURCS writer also checks whether the molecule generated from the WURCS string
  * (generated from the input molecule) would generate the same WURCS string again, to validate the uniqueness
  * of the identifier, but this is not necessary here because we are not displaying/exporting the WURCS string.

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/algorithm/MolWURCSFragmenter.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/algorithm/MolWURCSFragmenter.java
@@ -59,6 +59,11 @@ import java.util.logging.Logger;
  * <a href="https://pubs.acs.org/doi/full/10.1021/ci400571e">WURCS glycoside identifier</a>
  * available in MORTAR, using the <a href="https://doi.org/10.1007/s00216-024-05508-1">MolWURCS</a>
  * implementation of the identifier.
+ * Note: we are not giving the option (via a setting) to validate ("double-check") the generated WURCS string
+ * in side the WURCSWriter because we are anyway retranslating the generated WURCS string back into a molecule.
+ * The "double-check" routine of WURCS writer also checks whether the molecule generated from the WURCS string
+ * (generated from the input molecule) would generate the same WURCS string again, to validate the uniqueness
+ * of the identifier, but this is not necessary here because we are not displaying/exporting the WURCS string.
  *
  * @author Jonas Schaub
  * @version 1.0.0.0
@@ -74,16 +79,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
      * Default value for whether the aglycone part should be included in the output fragments.
      */
     public static final boolean OUTPUT_WITH_AGLYCONE_SETTING_DEFAULT = false;
-
-    /**
-     * Default value for whether double check should be performed in WURCSWriter.
-     */
-    public static final boolean DOUBLE_CHECK_SETTING_DEFAULT = false;
-
-    /**
-     * Default value for whether WURCS normalization should be applied before retranslating WURCS to molecule.
-     */
-    public static final boolean NORMALIZE_WURCS_BEFORE_RETRANSLATION_DEFAULT = true;
     //</editor-fold>
     //
     //<editor-fold desc="Private final variables">
@@ -106,16 +101,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
      * Property for whether the aglycone part should be included in the output fragments.
      */
     private final SimpleBooleanProperty outputWithAglyconeSetting;
-
-    /**
-     * Property for whether double check should be performed in WURCSWriter.
-     */
-    private final SimpleBooleanProperty doubleCheckSetting;
-
-    /**
-     * Property for whether WURCS normalization should be applied before retranslating WURCS to molecule.
-     */
-    private final SimpleBooleanProperty normalizeWURCSBeforeRetranslationSetting;
     //</editor-fold>
     //
     //<editor-fold desc="Private static final constants">
@@ -130,7 +115,7 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
      * Constructor, all settings are initialised with their default values.
      */
     public MolWURCSFragmenter() {
-        int tmpNumberOfSettings = 3;
+        int tmpNumberOfSettings = 1;
         this.settings = new ArrayList<>(tmpNumberOfSettings);
         int tmpInitialCapacityForSettingMaps = CollectionUtil.calculateInitialHashCollectionCapacity(
                 tmpNumberOfSettings,
@@ -144,21 +129,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
                 Message.get("MolWURCSFragmenter.outputWithAglyconeSetting.displayName"));
         this.settingNameTooltipTextMap.put(this.outputWithAglyconeSetting.getName(),
                 Message.get("MolWURCSFragmenter.outputWithAglyconeSetting.tooltip"));
-        this.doubleCheckSetting = new SimpleBooleanProperty(this, "Double check setting",
-                MolWURCSFragmenter.DOUBLE_CHECK_SETTING_DEFAULT);
-        this.settings.add(this.doubleCheckSetting);
-        this.settingNameDisplayNameMap.put(this.doubleCheckSetting.getName(),
-                Message.get("MolWURCSFragmenter.doubleCheckSetting.displayName"));
-        this.settingNameTooltipTextMap.put(this.doubleCheckSetting.getName(),
-                Message.get("MolWURCSFragmenter.doubleCheckSetting.tooltip"));
-        this.normalizeWURCSBeforeRetranslationSetting = new SimpleBooleanProperty(this,
-                "Normalize WURCS before retranslation setting",
-                MolWURCSFragmenter.NORMALIZE_WURCS_BEFORE_RETRANSLATION_DEFAULT);
-        this.settings.add(this.normalizeWURCSBeforeRetranslationSetting);
-        this.settingNameDisplayNameMap.put(this.normalizeWURCSBeforeRetranslationSetting.getName(),
-                Message.get("MolWURCSFragmenter.normalizeWURCSBeforeRetranslationSetting.displayName"));
-        this.settingNameTooltipTextMap.put(this.normalizeWURCSBeforeRetranslationSetting.getName(),
-                Message.get("MolWURCSFragmenter.normalizeWURCSBeforeRetranslationSetting.tooltip"));
     }
     //</editor-fold>
     //
@@ -172,23 +142,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
         return this.outputWithAglyconeSetting.get();
     }
 
-    /**
-     * Returns the currently set value of the double check setting.
-     *
-     * @return true, if double check is enabled; false, otherwise
-     */
-    public boolean getDoubleCheckSetting() {
-        return this.doubleCheckSetting.get();
-    }
-
-    /**
-     * Returns the currently set value of the 'normalize WURCS before retranslation setting'.
-     *
-     * @return true, if WURCS normalization is applied before retranslating WURCS to molecule; false, otherwise
-     */
-    public boolean getNormalizeWURCSBeforeRetranslationSetting() {
-        return this.normalizeWURCSBeforeRetranslationSetting.get();
-    }
     //</editor-fold>
     //
     //<editor-fold desc="Public properties set">
@@ -199,24 +152,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
      */
     public void setOutputWithAglyconeSetting(boolean aBoolean) {
         this.outputWithAglyconeSetting.set(aBoolean);
-    }
-
-    /**
-     * Sets the value of the double check setting.
-     *
-     * @param aBoolean true, if double check should be performed by the WURCSWriter; false, otherwise
-     */
-    public void setDoubleCheckSetting(boolean aBoolean) {
-        this.doubleCheckSetting.set(aBoolean);
-    }
-
-    /**
-     * Sets the value of the 'normalize WURCS before retranslation' setting.
-     *
-     * @param aBoolean true, if WURCS normalization should be applied before retranslating WURCS to molecule; false, otherwise
-     */
-    public void setNormalizeWURCSBeforeRetranslationSetting(boolean aBoolean) {
-        this.normalizeWURCSBeforeRetranslationSetting.set(aBoolean);
     }
     //</editor-fold>
     //
@@ -252,16 +187,12 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
     public IMoleculeFragmenter copy() {
         MolWURCSFragmenter tmpCopy = new MolWURCSFragmenter();
         tmpCopy.setOutputWithAglyconeSetting(this.getOutputWithAglyconeSetting());
-        tmpCopy.setDoubleCheckSetting(this.getDoubleCheckSetting());
-        tmpCopy.setNormalizeWURCSBeforeRetranslationSetting(this.getNormalizeWURCSBeforeRetranslationSetting());
         return tmpCopy;
     }
 
     @Override
     public void restoreDefaultSettings() {
         this.outputWithAglyconeSetting.set(MolWURCSFragmenter.OUTPUT_WITH_AGLYCONE_SETTING_DEFAULT);
-        this.doubleCheckSetting.set(MolWURCSFragmenter.DOUBLE_CHECK_SETTING_DEFAULT);
-        this.normalizeWURCSBeforeRetranslationSetting.set(MolWURCSFragmenter.NORMALIZE_WURCS_BEFORE_RETRANSLATION_DEFAULT);
     }
 
     @Override
@@ -280,7 +211,6 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
         //note: safer to always initialise a new writer
         WURCSWriter tmpWURCSWriter = new WURCSWriter(tmpStringWriter);
         tmpWURCSWriter.setOutputWithAglycone(this.outputWithAglyconeSetting.get());
-        tmpWURCSWriter.setDoDoubleCheck(this.doubleCheckSetting.get());
         //set property key for molecule title for log messages
         tmpWURCSWriter.setTitlePropertyID(Importer.MOLECULE_NAME_PROPERTY_KEY);
         //little preprocessing to prevent WURCS from trying to deduce stereo config from coordinates that are not there
@@ -324,8 +254,10 @@ public class MolWURCSFragmenter implements IMoleculeFragmenter {
             }
             WURCSFactory tmpWURCSFactory;
             try {
+                //note, the WURCSParser in MolWURCS is package-private unfortunately; here, I basically copied what it
+                // would do internally
                 //factory has to be newly instantiated for every molecule
-                tmpWURCSFactory = new WURCSFactory(tmpWURCSCode, this.normalizeWURCSBeforeRetranslationSetting.get());
+                tmpWURCSFactory = new WURCSFactory(tmpWURCSCode);
                 WURCSGraph tmpWURCSGraph = tmpWURCSFactory.getGraph();
                 try {
                     tmpWURCSGraphToMol.start(tmpWURCSGraph);

--- a/src/main/resources/de/unijena/cheminf/mortar/message/Message_en_GB.properties
+++ b/src/main/resources/de/unijena/cheminf/mortar/message/Message_en_GB.properties
@@ -450,7 +450,7 @@ SugarRemovalUtilityFragmenter.SRUFragmenterPreservationMode.MW.tooltip = Specifi
 ##MolWURCSFragmenter##
 MolWURCSFragmenter.displayName = MolWURCS
 MolWURCSFragmenter.outputWithAglyconeSetting.displayName = Output with aglycone setting
-MolWURCSFragmenter.outputWithAglyconeSetting.tooltip = Defines whether the output should contain the aglycone part of the molecule in addition to the sugar fragments; if turned on, sugar-containing molecules will be returned as fragments as a whole (only normalized according to WURCS rules, were applicable)
+MolWURCSFragmenter.outputWithAglyconeSetting.tooltip = Defines whether the output should contain the aglycone part of the molecule in addition to the sugar fragments; if turned on, sugar-containing molecules will be returned as fragments as a whole (only normalized according to WURCS rules, where applicable)
 ##SettingsContainer##
 SettingsContainer.rowsPerPageSetting.tooltip = Defines how many rows (i.e. molecules or fragments) should be displayed per page
 SettingsContainer.rowsPerPageSetting.displayName = Rows per page setting

--- a/src/main/resources/de/unijena/cheminf/mortar/message/Message_en_GB.properties
+++ b/src/main/resources/de/unijena/cheminf/mortar/message/Message_en_GB.properties
@@ -450,11 +450,7 @@ SugarRemovalUtilityFragmenter.SRUFragmenterPreservationMode.MW.tooltip = Specifi
 ##MolWURCSFragmenter##
 MolWURCSFragmenter.displayName = MolWURCS
 MolWURCSFragmenter.outputWithAglyconeSetting.displayName = Output with aglycone setting
-MolWURCSFragmenter.outputWithAglyconeSetting.tooltip = Defines whether the output should contain the aglycone part of the molecule in addition to the sugar fragments
-MolWURCSFragmenter.doubleCheckSetting.displayName = Double check setting
-MolWURCSFragmenter.doubleCheckSetting.tooltip = Defines whether the generated WURCS string should be double-checked by WURCS to WURCS conversion
-MolWURCSFragmenter.normalizeWURCSBeforeRetranslationSetting.displayName = Normalize WURCS before retranslation setting
-MolWURCSFragmenter.normalizeWURCSBeforeRetranslationSetting.tooltip = Defines whether the generated WURCS string should be normalized before retranslating it into a molecule
+MolWURCSFragmenter.outputWithAglyconeSetting.tooltip = Defines whether the output should contain the aglycone part of the molecule in addition to the sugar fragments; if turned on, sugar-containing molecules will be returned as fragments as a whole (only normalized according to WURCS rules, were applicable)
 ##SettingsContainer##
 SettingsContainer.rowsPerPageSetting.tooltip = Defines how many rows (i.e. molecules or fragments) should be displayed per page
 SettingsContainer.rowsPerPageSetting.displayName = Rows per page setting


### PR DESCRIPTION
After studying the literature again, I removed two settings from the MolWURCS fragmenter and made sure that there are no other settings we could offer available in the MolWURCS library. Still to do: update the MORTAR tutorial accordingly. After this is merged, I would also like to make a new release.

Copilot summary:
This pull request simplifies the configuration of the `MolWURCSFragmenter` class by removing two settings related to WURCS string validation and normalization, leaving only the aglycone output option. The code and UI have been updated accordingly to reflect this streamlined approach.

**Settings removal and simplification:**

* Removed the `doubleCheckSetting` and `normalizeWURCSBeforeRetranslationSetting` options, including their properties, default values, and all associated getter/setter methods from `MolWURCSFragmenter`. The constructor and copy/restore methods were updated to only handle the aglycone output setting. [[1]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L77-L86) [[2]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L109-L118) [[3]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L133-R118) [[4]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L147-L161) [[5]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L175-L191) [[6]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L203-L220) [[7]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L255-L264)
* Updated the `fragmentMolecule` method to remove usage of the deleted settings, ensuring the WURCS writer and factory are now used with default behaviors. [[1]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6L283) [[2]](diffhunk://#diff-891c541e6401fd0d5b01548d8455329d5d84f7729e5c511b89c3a69999389be6R257-R260)

**Documentation and UI updates:**

* Revised the class-level JavaDoc in `MolWURCSFragmenter` to clarify why the double-check validation is not needed in this context.
* Cleaned up the English message properties file by removing references to the deleted settings and improving the aglycone setting tooltip for clarity.