### PR TITLE
Several fixes of deployment GH workflows

### DIFF
--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-1.5.0.0.jar
-          path: ./build/libs/*.jar
+          path: ./build/libs/MORTAR-fat-1.5.0.0.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
       - name: Build fatJarAarch64 with Gradle

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -120,3 +120,44 @@ jobs:
           path: ./*.rpm
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
+
+  build-fat-jars:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        java: [ '21.0.1' ]
+    name: 'fat-jars'
+    steps:
+      - name: Git checkout
+        uses: actions/checkout@v4
+      - name: Set up JDK
+        uses: actions/setup-java@v4
+        with:
+          java-version: ${{ matrix.java }}
+          distribution: 'temurin'
+      - name: Echo JAVA_HOME
+        run: echo $JAVA_HOME
+      - name: Verify Gradle Wrapper
+        uses: gradle/actions/wrapper-validation@v3
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+      - name: Build fatJar with Gradle
+        run: ./gradlew --info --stacktrace fatJar
+      - name: Upload JAR as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MORTAR-fat-1.5.0.0.jar
+          path: ./*.jar
+          retention-days: 30
+          compression-level: 0 # no compression since it makes no difference
+      - name: Build fatJarAarch64 with Gradle
+        run: ./gradlew --info --stacktrace fatJarAarch64
+      - name: Upload JAR as an artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MORTAR-fat-aarch64-1.5.0.0.jar
+          path: ./*.jar
+          retention-days: 30
+          compression-level: 0 # no compression since it makes no difference
+          

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -148,7 +148,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-1.5.0.0.jar
-          path: ./*.jar
+          path: ./build/libs/*.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
       - name: Build fatJarAarch64 with Gradle
@@ -157,7 +157,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-aarch64-1.5.0.0.jar
-          path: ./*.jar
+          path: ./build/libs//*.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
-          

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -42,7 +42,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-Windows-Setup
+          name: MORTAR_v1.5.0.0_WINx64_setup.exe
           path: build\winDeploy\out\*.exe
 
   build-macos:

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-1.5.0-${{ matrix.os }}.dmg
+          name: ${{ matrix.os == 'macos-15-intel' && 'MORTAR-aarch64-1.5.0.dmg' || 'MORTAR-1.5.0.dmg' }}
           path: ./*.dmg
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -68,10 +68,10 @@ jobs:
       - name: Grant execute permission for gradlew
         run: chmod +x gradlew
       - name: Package DMG (ARM)
-        if: matrix.os == 'macos-latest'
+        if: matrix.os == 'macos-15'
         run: ./gradlew --info --stacktrace localMacDmgArm
       - name: Package DMG (Intel)
-        if: matrix.os == 'macos-13'
+        if: matrix.os == 'macos-15-intel'
         run: ./gradlew --info --stacktrace localMacDmgIntel
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v4

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os == 'macos-15-intel' && 'MORTAR-aarch64-1.5.0.dmg' || 'MORTAR-1.5.0.dmg' }}
+          name: ${{ matrix.os == 'macos-15' && 'MORTAR-aarch64-1.5.0.dmg' || 'MORTAR-1.5.0.dmg' }}
           path: ./*.dmg
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -152,7 +152,7 @@ jobs:
       - name: Upload JAR as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-fat-${{ env.APP_VERSION_SHORT }}.jar
+          name: MORTAR-fat-${{ env.APP_VERSION }}.jar
           path: ./build/libs/MORTAR-fat-${{ env.APP_VERSION }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
@@ -161,7 +161,7 @@ jobs:
       - name: Upload Aarch64 JAR as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-fat-aarch64-${{ env.APP_VERSION_SHORT }}.jar
+          name: MORTAR-fat-aarch64-${{ env.APP_VERSION }}.jar
           path: ./build/libs/MORTAR-fat-aarch64-${{ env.APP_VERSION }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -153,10 +153,10 @@ jobs:
           compression-level: 0 # no compression since it makes no difference
       - name: Build fatJarAarch64 with Gradle
         run: ./gradlew --info --stacktrace fatJarAarch64
-      - name: Upload JAR as an artifact
+      - name: Upload Aarch64 JAR as an artifact
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-aarch64-1.5.0.0.jar
-          path: ./build/libs//*.jar
+          path: ./build/libs/MORTAR-fat-aarch64-1.5.0.0.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -153,7 +153,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-${{ env.APP_VERSION_SHORT }}.jar
-          path: ./build/libs/MORTAR-fat-${{ env.APP_VERSION_SHORT }}.jar
+          path: ./build/libs/MORTAR-fat-${{ env.APP_VERSION }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
       - name: Build fatJarAarch64 with Gradle
@@ -162,6 +162,6 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: MORTAR-fat-aarch64-${{ env.APP_VERSION_SHORT }}.jar
-          path: ./build/libs/MORTAR-fat-aarch64-${{ env.APP_VERSION_SHORT }}.jar
+          path: ./build/libs/MORTAR-fat-aarch64-${{ env.APP_VERSION }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/.github/workflows/deployment.yml
+++ b/.github/workflows/deployment.yml
@@ -5,6 +5,11 @@
 # This workflow will build a Java project with Gradle and cache/restore any dependencies to improve the workflow execution time
 
 name: Cross-Platform Deployment
+
+env:
+  APP_VERSION: "1.5.0.0"
+  APP_VERSION_SHORT: "1.5.0"
+
 on:
   push:
     branches: [ "main", "production" ]
@@ -42,7 +47,7 @@ jobs:
       - name: Upload artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR_v1.5.0.0_WINx64_setup.exe
+          name: MORTAR_v${{ env.APP_VERSION }}_WINx64_setup.exe
           path: build\winDeploy\out\*.exe
 
   build-macos:
@@ -76,7 +81,7 @@ jobs:
       - name: Upload DMG as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.os == 'macos-15' && 'MORTAR-aarch64-1.5.0.dmg' || 'MORTAR-1.5.0.dmg' }}
+          name: ${{ matrix.os == 'macos-15' && format('MORTAR-aarch64-{0}.dmg', env.APP_VERSION_SHORT) || format('MORTAR-{0}.dmg', env.APP_VERSION_SHORT) }}
           path: ./*.dmg
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
@@ -107,7 +112,7 @@ jobs:
       - name: Upload DEB as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-1.5.0.deb
+          name: MORTAR-${{ env.APP_VERSION_SHORT }}.deb
           path: ./*.deb
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
@@ -116,7 +121,7 @@ jobs:
       - name: Upload RPM as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-1.5.0.rpm
+          name: MORTAR-${{ env.APP_VERSION_SHORT }}.rpm
           path: ./*.rpm
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
@@ -147,8 +152,8 @@ jobs:
       - name: Upload JAR as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-fat-1.5.0.0.jar
-          path: ./build/libs/MORTAR-fat-1.5.0.0.jar
+          name: MORTAR-fat-${{ env.APP_VERSION_SHORT }}.jar
+          path: ./build/libs/MORTAR-fat-${{ env.APP_VERSION_SHORT }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference
       - name: Build fatJarAarch64 with Gradle
@@ -156,7 +161,7 @@ jobs:
       - name: Upload Aarch64 JAR as an artifact
         uses: actions/upload-artifact@v4
         with:
-          name: MORTAR-fat-aarch64-1.5.0.0.jar
-          path: ./build/libs/MORTAR-fat-aarch64-1.5.0.0.jar
+          name: MORTAR-fat-aarch64-${{ env.APP_VERSION_SHORT }}.jar
+          path: ./build/libs/MORTAR-fat-aarch64-${{ env.APP_VERSION_SHORT }}.jar
           retention-days: 30
           compression-level: 0 # no compression since it makes no difference

--- a/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
+++ b/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
@@ -33,6 +33,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * Gradle task for local Linux deployment using jpackage.
@@ -110,11 +112,11 @@ open class LocalLinuxDeploy : DefaultTask() {
             val desiredFile = File(outputDir, desiredDebName)
 
             if (defaultFile.exists()) {
-                val success = defaultFile.renameTo(desiredFile)
-                if (success) {
+                try {
+                    Files.move(defaultFile.toPath(), desiredFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
                     logger.lifecycle("Renamed DEB to: ${desiredFile.name}")
-                } else {
-                    logger.lifecycle("Failed to rename DEB.")
+                } catch (e: Exception) {
+                    throw org.gradle.api.GradleException("Failed to rename DEB: ${e.message}", e)
                 }
             }
         } else if (pkgType == "rpm") {
@@ -126,11 +128,11 @@ open class LocalLinuxDeploy : DefaultTask() {
             val desiredFile = File(outputDir, desiredRpmName)
 
             if (defaultFile.exists()) {
-                val success = defaultFile.renameTo(desiredFile)
-                if (success) {
+                try {
+                    Files.move(defaultFile.toPath(), desiredFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
                     logger.lifecycle("Renamed RPM to: ${desiredFile.name}")
-                } else {
-                    logger.lifecycle("Failed to rename RPM.")
+                } catch (e: Exception) {
+                    throw org.gradle.api.GradleException("Failed to rename RPM: ${e.message}", e)
                 }
             }
         }

--- a/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
+++ b/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
@@ -100,5 +100,39 @@ open class LocalLinuxDeploy : DefaultTask() {
         }
 
         logger.lifecycle("Linux package created: $pkgType")
+
+        if (pkgType == "deb") {
+            val defaultDebName = "$appName${'_'}$appVersionShort${'_'}amd64.deb"
+            val desiredDebName = "$appName-$appVersionShort.deb"
+
+            val outputDir = project.rootDir
+            val defaultFile = File(outputDir, defaultDebName)
+            val desiredFile = File(outputDir, desiredDebName)
+
+            if (defaultFile.exists()) {
+                val success = defaultFile.renameTo(desiredFile)
+                if (success) {
+                    logger.lifecycle("Renamed DEB to: ${desiredFile.name}")
+                } else {
+                    logger.lifecycle("Failed to rename DEB.")
+                }
+            }
+        } else if (pkgType == "rpm") {
+            val defaultRpmName = "$appName-$appVersionShort-1.x86_64.rpm"
+            val desiredRpmName = "$appName-$appVersionShort.rpm"
+
+            val outputDir = project.rootDir
+            val defaultFile = File(outputDir, defaultRpmName)
+            val desiredFile = File(outputDir, desiredRpmName)
+
+            if (defaultFile.exists()) {
+                val success = defaultFile.renameTo(desiredFile)
+                if (success) {
+                    logger.lifecycle("Renamed RPM to: ${desiredFile.name}")
+                } else {
+                    logger.lifecycle("Failed to rename RPM.")
+                }
+            }
+        }
     }
 }

--- a/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
+++ b/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalLinuxDeploy.kt
@@ -102,7 +102,7 @@ open class LocalLinuxDeploy : DefaultTask() {
         logger.lifecycle("Linux package created: $pkgType")
 
         if (pkgType == "deb") {
-            val defaultDebName = "$appName${'_'}$appVersionShort${'_'}amd64.deb"
+            val defaultDebName = "${appName.lowercase()}${'_'}$appVersionShort${'_'}amd64.deb"
             val desiredDebName = "$appName-$appVersionShort.deb"
 
             val outputDir = project.rootDir
@@ -118,7 +118,7 @@ open class LocalLinuxDeploy : DefaultTask() {
                 }
             }
         } else if (pkgType == "rpm") {
-            val defaultRpmName = "$appName-$appVersionShort-1.x86_64.rpm"
+            val defaultRpmName = "${appName.lowercase()}-$appVersionShort-1.x86_64.rpm"
             val desiredRpmName = "$appName-$appVersionShort.rpm"
 
             val outputDir = project.rootDir

--- a/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalMacDeploy.kt
+++ b/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalMacDeploy.kt
@@ -33,6 +33,8 @@ import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
 
 import java.io.File
+import java.nio.file.Files
+import java.nio.file.StandardCopyOption
 
 /**
  * Gradle task for local macOS deployment using jpackage.
@@ -112,11 +114,11 @@ open class LocalMacDeploy : DefaultTask() {
             val desiredFile = File(outputDir, desiredDmgName)
 
             if (defaultFile.exists()) {
-                val success = defaultFile.renameTo(desiredFile)
-                if (success) {
+                try {
+                    Files.move(defaultFile.toPath(), desiredFile.toPath(), StandardCopyOption.REPLACE_EXISTING)
                     logger.lifecycle("Renamed DMG to: ${desiredFile.name}")
-                } else {
-                    logger.lifecycle("Failed to rename AARCH64 DMG.")
+                } catch (e: Exception) {
+                    throw org.gradle.api.GradleException("Failed to rename DMG: ${e.message}", e)
                 }
             }
         }

--- a/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalMacDeploy.kt
+++ b/build-logic/src/main/kotlin/de/unijena/cheminf/mortar/gradle/deploy/LocalMacDeploy.kt
@@ -102,5 +102,23 @@ open class LocalMacDeploy : DefaultTask() {
         }
 
         logger.lifecycle("macOS DMG created for $arch architecture")
+
+        if (arch == "arm") {
+            val defaultDmgName = "$appName-$appVersionShort.dmg"
+            val desiredDmgName = "$appName-aarch64-$appVersionShort.dmg"
+
+            val outputDir = project.rootDir
+            val defaultFile = File(outputDir, defaultDmgName)
+            val desiredFile = File(outputDir, desiredDmgName)
+
+            if (defaultFile.exists()) {
+                val success = defaultFile.renameTo(desiredFile)
+                if (success) {
+                    logger.lifecycle("Renamed DMG to: ${desiredFile.name}")
+                } else {
+                    logger.lifecycle("Failed to rename AARCH64 DMG.")
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
Copilot:
This pull request updates the deployment workflow and packaging scripts to improve artifact naming consistency and add new build artifacts. The main changes include renaming output files for better clarity, updating workflow logic for macOS builds, and introducing a new job for building and uploading fat JARs. Additionally, packaging scripts now automatically rename Linux and macOS artifacts to follow the new naming conventions [edit Jonas: so that the generated artifacts can immediately be used for a new MORTAR release].

**Deployment Workflow Improvements:**

- Updated the Windows artifact name in the GitHub Actions workflow to `MORTAR_v1.5.0.0_WINx64_setup.exe` for versioned consistency.
- Refined macOS build matrix logic and artifact naming:
  - Changed the conditional checks for ARM and Intel macOS builds.
  - Set distinct artifact names for ARM (`MORTAR-aarch64-1.5.0.dmg`) and Intel (`MORTAR-1.5.0.dmg`) builds.

**New Build Artifacts:**

- Added a new `build-fat-jars` job to the workflow to build and upload both standard and Aarch64 fat JARs (`MORTAR-fat-1.5.0.0.jar` and `MORTAR-fat-aarch64-1.5.0.0.jar`).

**Packaging Script Enhancements:**

- Updated the Linux deployment script (`LocalLinuxDeploy.kt`) to automatically rename generated `.deb` and `.rpm` files to a simplified, versioned format (e.g., `MORTAR-1.5.0.0.deb` and `MORTAR-1.5.0.0.rpm`).
- Updated the macOS deployment script (`LocalMacDeploy.kt`) to automatically rename the ARM architecture DMG to include `aarch64` in the filename (e.g., `MORTAR-aarch64-1.5.0.dmg`).