### PR TITLE
More detailed fragmentation metadata reporting

### DIFF
--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
@@ -1047,6 +1047,7 @@ public class FragmentationService {
         long tmpStartTime = System.currentTimeMillis();
         int tmpExceptionsCounter = 0;
         int tmpMoleculeProducedNoFragmentsCounter = 0;
+        int tmpMoleculeProducedFragmentsCounter = 0;
         int tmpMoleculeFailedGetAtomContainerCounter = 0;
         int tmpFilteredMoleculesCounter = 0;
         int tmpFragmentFailedSmilesGenerationCounter = 0;
@@ -1063,6 +1064,7 @@ public class FragmentationService {
                 if (!Objects.isNull(tmpResult)) {
                     tmpExceptionsCounter += tmpResult.exceptionsCount();
                     tmpMoleculeProducedNoFragmentsCounter += tmpResult.moleculeProducedNoFragmentsCount();
+                    tmpMoleculeProducedFragmentsCounter += tmpResult.moleculeProducedFragmentsCount();
                     tmpMoleculeFailedGetAtomContainerCounter += tmpResult.moleculeFailedGetAtomContainerCount();
                     tmpFilteredMoleculesCounter += tmpResult.filteredMoleculesCount();
                     tmpFragmentFailedSmilesGenerationCounter += tmpResult.fragmentFailedSmilesGenerationCount();
@@ -1118,26 +1120,46 @@ public class FragmentationService {
         } else {
             FragmentationService.LOGGER.log(Level.WARNING, "Sum of absolute frequencies of fragments was 0! Percentages could not be calculated.");
         }
-        if (tmpExceptionsCounter > 0) {
-            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused exceptions in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpExceptionsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
-        }
+        FragmentationService.LOGGER.log(Level.INFO,
+                "{0} molecules produced fragments and {1} molecules produced no(!) fragments in fragmentation \"{2}\" ({3}).",
+                new Object[]{tmpMoleculeProducedFragmentsCounter, tmpMoleculeProducedNoFragmentsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        FragmentationService.LOGGER.log(Level.INFO,
+                "{0} molecules were filtered according to the fragmentation algorithm rules.",
+                new Object[]{tmpFilteredMoleculesCounter});
         if (tmpMoleculeFailedGetAtomContainerCounter > 0) {
-            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules could not produce a valid atom container in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpMoleculeFailedGetAtomContainerCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+            FragmentationService.LOGGER.log(Level.WARNING,
+                    "{0} molecules could not produce a valid atom container.",
+                    new Object[]{tmpMoleculeFailedGetAtomContainerCounter});
         }
-        if (tmpFragmentFailedSmilesGenerationCounter > 0) {
-            FragmentationService.LOGGER.log(Level.WARNING, "{0} fragments could not be parsed to SMILES codes in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpFragmentFailedSmilesGenerationCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        if (tmpExceptionsCounter > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING,
+                    "{0} molecules caused exceptions during fragmentation.",
+                    new Object[]{tmpExceptionsCounter});
         }
         if (tmpUnexpectedExceptionsCounter > 0) {
-            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused unexpected exceptions in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpUnexpectedExceptionsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+            FragmentationService.LOGGER.log(Level.WARNING,
+                    "{0} molecules caused unexpected exceptions somewhere in the fragmentation process.",
+                    new Object[]{tmpUnexpectedExceptionsCounter});
         }
-        FragmentationService.LOGGER.log(Level.INFO, "{0} molecules were filtered according to the fragmentation algorithm rules in fragmentation \"{1}\" ({2}).",
-                new Object[]{tmpFilteredMoleculesCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
-        FragmentationService.LOGGER.log(Level.INFO, "{0} molecules produced no fragments in fragmentation \"{1}\" ({2}).",
-                new Object[]{tmpMoleculeProducedNoFragmentsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        if (tmpFragmentFailedSmilesGenerationCounter > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING,
+                    "{0} fragments could not be parsed to SMILES codes.",
+                    new Object[]{tmpFragmentFailedSmilesGenerationCounter});
+        }
+        int tmpUnaccountedMoleculesNr = aListOfMolecules.size()
+                - tmpMoleculeProducedNoFragmentsCounter
+                - tmpMoleculeProducedFragmentsCounter
+                - tmpFilteredMoleculesCounter
+                - tmpExceptionsCounter
+                - tmpUnexpectedExceptionsCounter
+                - tmpMoleculeFailedGetAtomContainerCounter;
+        if (tmpUnaccountedMoleculesNr > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING,
+                    "The relevant fragmentation counters do not sum up to " +
+                    "the total nr. of molecules that were submitted for fragmentation! " +
+                    "{0} molecules are unaccounted for!",
+                    new Object[]{tmpUnaccountedMoleculesNr});
+        }
         this.executorService.shutdown();
         tmpMemoryConsumption = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
         long tmpEndTime = System.currentTimeMillis();

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
@@ -1120,24 +1120,24 @@ public class FragmentationService {
         }
         if (tmpExceptionsCounter > 0) {
             FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused exceptions in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                    new Object[]{tmpExceptionsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         }
         if (tmpMoleculeFailedGetAtomContainerCounter > 0) {
             FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules could not produce a valid atom container in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                    new Object[]{tmpMoleculeFailedGetAtomContainerCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         }
         if (tmpFragmentFailedSmilesGenerationCounter > 0) {
             FragmentationService.LOGGER.log(Level.WARNING, "{0} fragments could not be parsed to SMILES codes in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpFragmentFailedSmilesGenerationCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                    new Object[]{tmpFragmentFailedSmilesGenerationCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         }
         if (tmpUnexpectedExceptionsCounter > 0) {
             FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused unexpected exceptions in fragmentation \"{1}\" ({2}).",
-                    new Object[]{tmpUnexpectedExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                    new Object[]{tmpUnexpectedExceptionsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         }
         FragmentationService.LOGGER.log(Level.INFO, "{0} molecules were filtered according to the fragmentation algorithm rules in fragmentation \"{1}\" ({2}).",
-                new Object[]{tmpFilteredMoleculesCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                new Object[]{tmpFilteredMoleculesCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         FragmentationService.LOGGER.log(Level.INFO, "{0} molecules produced no fragments in fragmentation \"{1}\" ({2}).",
-                new Object[]{tmpMoleculeProducedNoFragmentsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+                new Object[]{tmpMoleculeProducedNoFragmentsCounter, aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         this.executorService.shutdown();
         tmpMemoryConsumption = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
         long tmpEndTime = System.currentTimeMillis();

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationService.java
@@ -1040,23 +1040,33 @@ public class FragmentationService {
                 tmpToIndex = aListOfMolecules.size();
             }
         }
-        List<Future<Integer>> tmpFuturesList;
+        List<Future<FragmentationTaskResult>> tmpFuturesList;
         long tmpMemoryConsumption = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
         FragmentationService.LOGGER.log(Level.INFO, "Fragmentation \"{0}\" ({1}) starting. Current memory consumption: {2} MB",
                 new Object[]{aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName(), tmpMemoryConsumption});
         long tmpStartTime = System.currentTimeMillis();
         int tmpExceptionsCounter = 0;
+        int tmpMoleculeProducedNoFragmentsCounter = 0;
+        int tmpMoleculeFailedGetAtomContainerCounter = 0;
+        int tmpFilteredMoleculesCounter = 0;
+        int tmpFragmentFailedSmilesGenerationCounter = 0;
+        int tmpUnexpectedExceptionsCounter = 0;
         tmpFuturesList = this.executorService.invokeAll(tmpFragmentationTaskList);
         if (this.executorService.isShutdown() || this.executorService.isTerminated()) {
             FragmentationService.LOGGER.log(Level.INFO, "Fragmentation cancelled");
             return null;
         }
         List<Exception> tmpFutureExceptionsList = new ArrayList<>(tmpFuturesList.size());
-        for (Future<Integer> tmpFuture : tmpFuturesList) {
+        for (Future<FragmentationTaskResult> tmpFuture : tmpFuturesList) {
             try {
-                Integer tmpResult = tmpFuture.get();
+                FragmentationTaskResult tmpResult = tmpFuture.get();
                 if (!Objects.isNull(tmpResult)) {
-                    tmpExceptionsCounter += tmpFuture.get();
+                    tmpExceptionsCounter += tmpResult.exceptionsCount();
+                    tmpMoleculeProducedNoFragmentsCounter += tmpResult.moleculeProducedNoFragmentsCount();
+                    tmpMoleculeFailedGetAtomContainerCounter += tmpResult.moleculeFailedGetAtomContainerCount();
+                    tmpFilteredMoleculesCounter += tmpResult.filteredMoleculesCount();
+                    tmpFragmentFailedSmilesGenerationCounter += tmpResult.fragmentFailedSmilesGenerationCount();
+                    tmpUnexpectedExceptionsCounter += tmpResult.unexpectedExceptionsCount();
                 } else {
                     // go to catch
                     throw new ExecutionException(new MORTARException("Result of parallel computation task was null for unknown reason."));
@@ -1109,9 +1119,25 @@ public class FragmentationService {
             FragmentationService.LOGGER.log(Level.WARNING, "Sum of absolute frequencies of fragments was 0! Percentages could not be calculated.");
         }
         if (tmpExceptionsCounter > 0) {
-            FragmentationService.LOGGER.log(Level.WARNING, "Fragmentation \"{0}\" ({1}) caused {2} exceptions",
-                    new Object[]{aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName(), tmpExceptionsCounter});
+            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused exceptions in fragmentation \"{1}\" ({2}).",
+                    new Object[]{tmpExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         }
+        if (tmpMoleculeFailedGetAtomContainerCounter > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules could not produce a valid atom container in fragmentation \"{1}\" ({2}).",
+                    new Object[]{tmpExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        }
+        if (tmpFragmentFailedSmilesGenerationCounter > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING, "{0} fragments could not be parsed to SMILES codes in fragmentation \"{1}\" ({2}).",
+                    new Object[]{tmpFragmentFailedSmilesGenerationCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        }
+        if (tmpUnexpectedExceptionsCounter > 0) {
+            FragmentationService.LOGGER.log(Level.WARNING, "{0} molecules caused unexpected exceptions in fragmentation \"{1}\" ({2}).",
+                    new Object[]{tmpUnexpectedExceptionsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        }
+        FragmentationService.LOGGER.log(Level.INFO, "{0} molecules were filtered according to the fragmentation algorithm rules in fragmentation \"{1}\" ({2}).",
+                new Object[]{tmpFilteredMoleculesCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
+        FragmentationService.LOGGER.log(Level.INFO, "{0} molecules produced no fragments in fragmentation \"{1}\" ({2}).",
+                new Object[]{tmpMoleculeProducedNoFragmentsCounter,aFragmentationName, aFragmenter.getFragmentationAlgorithmDisplayName()});
         this.executorService.shutdown();
         tmpMemoryConsumption = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
         long tmpEndTime = System.currentTimeMillis();

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTask.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTask.java
@@ -50,7 +50,7 @@ import java.util.logging.Logger;
  * @author Jonas Schaub
  * @version 1.0.0.0
  */
-public class FragmentationTask implements Callable<Integer> {
+public class FragmentationTask implements Callable<FragmentationTaskResult> {
     //<editor-fold desc="private static final class constants" defaultstate="collapsed">
     /**
      * Lock to be used when updating the shared fragmentsHashTable. Needs to be static to be shared between all task
@@ -84,10 +84,6 @@ public class FragmentationTask implements Callable<Integer> {
      * Whether stereochemistry in the fragments should be regarded when creating their SMILES codes.
      */
     private final boolean isStereochemistryRegarded;
-    /**
-     * Integer to count possible exceptions which could occur during fragmentation.
-     */
-    private int exceptionsCounter;
     //</editor-fold>
     //
     /**
@@ -111,7 +107,6 @@ public class FragmentationTask implements Callable<Integer> {
         this.fragmentsHashTable = aHashtableOfFragments;
         this.fragmentationName = aFragmentationName;
         this.isStereochemistryRegarded = isStereo;
-        this.exceptionsCounter = 0;
     }
     //
     /**
@@ -122,7 +117,13 @@ public class FragmentationTask implements Callable<Integer> {
      * @throws Exception if unable to compute a result (copied from doc in Callable interface)
      */
     @Override
-    public Integer call() throws Exception {
+    public FragmentationTaskResult call() throws Exception {
+        int tmpExceptionsCounter = 0;
+        int tmpMoleculeProducedNoFragmentsCounter = 0;
+        int tmpMoleculeFailedGetAtomContainerCounter = 0;
+        int tmpFilteredMoleculesCounter = 0;
+        int tmpFragmentFailedSmilesGenerationCounter = 0;
+        int tmpUnexpectedExceptionsCounter = 0;
         for (MoleculeDataModel tmpMolecule : this.moleculesList) {
             try {
                 IAtomContainer tmpAtomContainer;
@@ -130,7 +131,7 @@ public class FragmentationTask implements Callable<Integer> {
                     tmpAtomContainer = tmpMolecule.getAtomContainer();
                 }
                 catch(CDKException anException) {
-                    this.exceptionsCounter++;
+                    tmpMoleculeFailedGetAtomContainerCounter++;
                     Logger.getLogger(MoleculeDataModel.class.getName()).log(
                             Level.SEVERE, String.format("%s Molecule name: %s", anException.toString(), tmpMolecule.getName()), anException);
                     continue;
@@ -139,6 +140,7 @@ public class FragmentationTask implements Callable<Integer> {
                 if (this.fragmenter.shouldBeFiltered(tmpAtomContainer)) {
                     tmpMolecule.getAllFragments().put(this.fragmentationName, new ArrayList<>(0));
                     tmpMolecule.getFragmentFrequencies().put(this.fragmentationName, new HashMap<>(0));
+                    tmpFilteredMoleculesCounter++;
                     continue;
                 }
                 if (this.fragmenter.shouldBePreprocessed(tmpAtomContainer)) {
@@ -150,9 +152,15 @@ public class FragmentationTask implements Callable<Integer> {
                 }
                 catch (NullPointerException | IllegalArgumentException | CloneNotSupportedException anException) {
                     FragmentationTask.LOGGER.log(Level.SEVERE, anException.toString(), anException);
-                    this.exceptionsCounter++;
+                    tmpExceptionsCounter++;
                     tmpMolecule.getAllFragments().put(this.fragmentationName, new ArrayList<>(0));
                     tmpMolecule.getFragmentFrequencies().put(this.fragmentationName, new HashMap<>(0));
+                    continue;
+                }
+                if (tmpFragmentsList.isEmpty()) {
+                    tmpMolecule.getAllFragments().put(this.fragmentationName, new ArrayList<>(0));
+                    tmpMolecule.getFragmentFrequencies().put(this.fragmentationName, new HashMap<>(0));
+                    tmpMoleculeProducedNoFragmentsCounter++;
                     continue;
                 }
                 // list of all fragments for this molecule
@@ -163,7 +171,7 @@ public class FragmentationTask implements Callable<Integer> {
                 for (IAtomContainer tmpFragment : tmpFragmentsList) {
                     String tmpSmiles = ChemUtil.createUniqueSmiles(tmpFragment, this.isStereochemistryRegarded);
                     if (tmpSmiles == null) {
-                        this.exceptionsCounter++;
+                        tmpFragmentFailedSmilesGenerationCounter++;
                         continue;
                     }
                     // create new FragmentDataModel
@@ -189,9 +197,8 @@ public class FragmentationTask implements Callable<Integer> {
                 }
                 tmpMolecule.getFragmentFrequencies().put(this.fragmentationName, tmpFragmentFrequenciesOfMoleculeMap);
                 tmpMolecule.getAllFragments().put(this.fragmentationName, tmpFragmentsOfMolList);
-            }
-            catch(Exception anException) {
-                this.exceptionsCounter++;
+            } catch (Exception anException) {
+                tmpUnexpectedExceptionsCounter++;
                 FragmentationTask.LOGGER.log(Level.SEVERE, String.format("Exception while fragmenting molecule with name: %s", tmpMolecule.getName()), anException);
                 if (tmpMolecule.getAllFragments() != null && !tmpMolecule.getAllFragments().containsKey(this.fragmentationName)) {
                     tmpMolecule.getAllFragments().put(this.fragmentationName, new ArrayList<>(0));
@@ -205,6 +212,13 @@ public class FragmentationTask implements Callable<Integer> {
                 return null;
             }
         }
-        return this.exceptionsCounter;
+        return new FragmentationTaskResult(
+                tmpExceptionsCounter,
+                tmpMoleculeProducedNoFragmentsCounter,
+                tmpMoleculeFailedGetAtomContainerCounter,
+                tmpFilteredMoleculesCounter,
+                tmpFragmentFailedSmilesGenerationCounter,
+                tmpUnexpectedExceptionsCounter
+        );
     }
 }

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTask.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTask.java
@@ -120,6 +120,7 @@ public class FragmentationTask implements Callable<FragmentationTaskResult> {
     public FragmentationTaskResult call() throws Exception {
         int tmpExceptionsCounter = 0;
         int tmpMoleculeProducedNoFragmentsCounter = 0;
+        int tmpMoleculeProducedFragmentsCounter = 0;
         int tmpMoleculeFailedGetAtomContainerCounter = 0;
         int tmpFilteredMoleculesCounter = 0;
         int tmpFragmentFailedSmilesGenerationCounter = 0;
@@ -162,6 +163,8 @@ public class FragmentationTask implements Callable<FragmentationTaskResult> {
                     tmpMolecule.getFragmentFrequencies().put(this.fragmentationName, new HashMap<>(0));
                     tmpMoleculeProducedNoFragmentsCounter++;
                     continue;
+                } else {
+                    tmpMoleculeProducedFragmentsCounter++;
                 }
                 // list of all fragments for this molecule
                 List<FragmentDataModel> tmpFragmentsOfMolList = new ArrayList<>(tmpFragmentsList.size());
@@ -215,6 +218,7 @@ public class FragmentationTask implements Callable<FragmentationTaskResult> {
         return new FragmentationTaskResult(
                 tmpExceptionsCounter,
                 tmpMoleculeProducedNoFragmentsCounter,
+                tmpMoleculeProducedFragmentsCounter,
                 tmpMoleculeFailedGetAtomContainerCounter,
                 tmpFilteredMoleculesCounter,
                 tmpFragmentFailedSmilesGenerationCounter,

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTaskResult.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTaskResult.java
@@ -1,0 +1,48 @@
+/*
+ * MORTAR - MOlecule fRagmenTAtion fRamework
+ * Copyright (C) 2026  Felix Baensch, Jonas Schaub (felix.j.baensch@gmail.com, jonas.schaub@uni-jena.de)
+ *
+ * Source code is available at <https://github.com/FelixBaensch/MORTAR>
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+package de.unijena.cheminf.mortar.model.fragmentation;
+
+/**
+ * Data record class for detailed fragmentation task results reporting.
+ *
+ * @param exceptionsCount                     Nr. of exceptions that happened during molecule fragmentation.
+ * @param moleculeProducedNoFragmentsCount    Nr. of molecules that were successfully(!) fragmented but produced no fragments.
+ * @param moleculeFailedGetAtomContainerCount Nr. of molecules that gave no atom container.
+ * @param filteredMoleculesCount              Nr. of molecules that were filtered according to the respective fragmentation algorithm method.
+ * @param fragmentFailedSmilesGenerationCount Nr. of fragments that produced no SMILES code.
+ * @param unexpectedExceptionsCount           Nr. of unexpected exceptions that happened during molecule fragmentation (i.e. the whole process of preprocessing,
+ *                                            fragmentation, and results analysis for one molecule).
+ * @author Jonas Schaub
+ * @version 1.0.0.0
+ */
+public record FragmentationTaskResult(
+        int exceptionsCount,
+        int moleculeProducedNoFragmentsCount,
+        int moleculeFailedGetAtomContainerCount,
+        int filteredMoleculesCount,
+        int fragmentFailedSmilesGenerationCount,
+        int unexpectedExceptionsCount
+) {}

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTaskResult.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationTaskResult.java
@@ -30,6 +30,7 @@ package de.unijena.cheminf.mortar.model.fragmentation;
  *
  * @param exceptionsCount                     Nr. of exceptions that happened during molecule fragmentation.
  * @param moleculeProducedNoFragmentsCount    Nr. of molecules that were successfully(!) fragmented but produced no fragments.
+ * @param moleculeProducedFragmentsCount      Nr. of molecules that were successfully(!) fragmented and produced fragments (to check whether all molecules are accounted for).
  * @param moleculeFailedGetAtomContainerCount Nr. of molecules that gave no atom container.
  * @param filteredMoleculesCount              Nr. of molecules that were filtered according to the respective fragmentation algorithm method.
  * @param fragmentFailedSmilesGenerationCount Nr. of fragments that produced no SMILES code.
@@ -41,6 +42,7 @@ package de.unijena.cheminf.mortar.model.fragmentation;
 public record FragmentationTaskResult(
         int exceptionsCount,
         int moleculeProducedNoFragmentsCount,
+        int moleculeProducedFragmentsCount,
         int moleculeFailedGetAtomContainerCount,
         int filteredMoleculesCount,
         int fragmentFailedSmilesGenerationCount,

--- a/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationThread.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/fragmentation/FragmentationThread.java
@@ -118,7 +118,7 @@ public class FragmentationThread implements Callable<Hashtable<String, FragmentD
                 tmpToIndex = this.molecules.size();
             }
         }
-        List<Future<Integer>> tmpFuturesList;
+        List<Future<FragmentationTaskResult>> tmpFuturesList;
         long tmpMemoryConsumption = (Runtime.getRuntime().totalMemory() - Runtime.getRuntime().freeMemory()) / (1024*1024);
         FragmentationThread.LOGGER.info("Fragmentation \"" + this.fragmentationName
                 + "\" starting. Current memory consumption: " + tmpMemoryConsumption + " MB");
@@ -130,8 +130,8 @@ public class FragmentationThread implements Callable<Hashtable<String, FragmentD
             throw anException;
         }
         int tmpExceptionsCounter = 0;
-        for (Future<Integer> tmpFuture : tmpFuturesList) {
-            tmpExceptionsCounter += tmpFuture.get();
+        for (Future<FragmentationTaskResult> tmpFuture : tmpFuturesList) {
+            tmpExceptionsCounter += tmpFuture.get().exceptionsCount();
         }
         int tmpFragmentAmount = 0;
         Set<String> tmpKeySet = tmpFragmentHashtable.keySet();


### PR DESCRIPTION
This pull request refactors the fragmentation process to provide more detailed reporting of task outcomes and improves error handling and logging. The main change is the introduction of a new `FragmentationTaskResult` record, which allows the system to track and report on a variety of specific outcomes during molecule fragmentation, rather than just counting general exceptions. This enables more granular logging and better diagnostics for users and developers.

The most important changes are:

**Fragmentation Task Result Refactoring:**

* Introduced a new record class `FragmentationTaskResult` to encapsulate detailed results from each fragmentation task, including counts for exceptions, molecules producing no fragments, failures in atom container generation, filtered molecules, SMILES generation failures, and unexpected exceptions.
* Changed `FragmentationTask` to implement `Callable<FragmentationTaskResult>` instead of `Callable<Integer>`, and updated its logic to track and return these detailed counts instead of a single exception counter. [[1]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L53-R53) [[2]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L125-R134) [[3]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L208-R222) [[4]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L87-L90) [[5]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L114) [[6]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750R143) [[7]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L153-R165) [[8]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L166-R174) [[9]](diffhunk://#diff-1fe790296fc43f252f631b0b163a1888c6c978ba48065817fd230b9982b9f750L192-R201)

**Integration with Fragmentation Services:**

* Updated `FragmentationService` and `FragmentationThread` to use `Future<FragmentationTaskResult>` instead of `Future<Integer>` and to aggregate the new detailed result counts across all tasks. [[1]](diffhunk://#diff-dc1a14403176e2f00f09f9ab2d015f104aa23a0b354eeb8073ac8d456af16c29L1043-R1069) [[2]](diffhunk://#diff-e2a5be5cc70f8b2a500177fdeb07fab243d1023434ae92b41d801967e1e3ab54L121-R121) [[3]](diffhunk://#diff-e2a5be5cc70f8b2a500177fdeb07fab243d1023434ae92b41d801967e1e3ab54L133-R134)

**Enhanced Logging and Diagnostics:**

* Improved logging in `FragmentationService` to report not just the total number of exceptions, but also counts of specific issues (e.g., molecules failing to produce atom containers, fragments failing SMILES generation, molecules filtered out, and unexpected exceptions). This provides clearer diagnostics for users and easier debugging for developers.

These changes collectively make the fragmentation process more robust, transparent, and maintainable by providing finer-grained feedback on task outcomes.