### PR TITLE
Update CDK from snapshot release to full release 2.12

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ will take care of it automatically.
 * JavaFX version 21.0.1
   * [Open JavaFX](https://openjfx.io)
   * GNU General Public License (GPL) Version 2
-* Chemistry Development Kit (CDK) version 2.12-SNAPSHOT
+* Chemistry Development Kit (CDK) version 2.12
     * [Chemistry Development Kit on GitHub](https://cdk.github.io/)
     * License: GNU Lesser General Public License 2.1
 * MolWURCS version 0.12.1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -25,7 +25,7 @@ java {
 repositories {
     mavenCentral()
     // CDK SNAPSHOT repository, uncomment if needed
-    maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
+    //maven { url = uri("https://central.sonatype.com/repository/maven-snapshots/") }
     // GitLab Maven repository for MolWURCS
     maven { url = uri("https://gitlab.com/api/v4/projects/20390948/packages/maven") }
     // GitLab Maven repository for WURCSFramework

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,7 +1,7 @@
 [versions]
 # libraries
 junit-version = "5.11.4"
-cdk-version = "2.12-SNAPSHOT"
+cdk-version = "2.12"
 cdkScaffold-version = "2.8"
 javafx-version = "21.0.1"
 openpdf-version = "2.0.3"

--- a/src/main/java/de/unijena/cheminf/mortar/model/io/Importer.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/io/Importer.java
@@ -60,6 +60,7 @@ import org.openscience.cdk.silent.SilentChemObjectBuilder;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
 import org.openscience.cdk.tools.manipulator.ChemFileManipulator;
+import org.openscience.cdk.tools.manipulator.HydrogenState;
 
 import java.io.BufferedInputStream;
 import java.io.BufferedReader;
@@ -601,11 +602,9 @@ public class Importer {
                         }
                     }
                 }
-                /* note: the doc says: "Suppress any explicit hydrogens in the provided container. Only hydrogens that
-                can be represented as a hydrogen count value on the atom are suppressed." Therefore, there will
-                still be some explicit hydrogen atoms!
-                 */
-                AtomContainerManipulator.suppressHydrogens(tmpMolecule);
+                /* note: the doc says: "All explicit hydrogens that can safely be converted to a count on their attached
+                atom will be suppressed." Therefore, there will still be some explicit hydrogen atoms! */
+                AtomContainerManipulator.normalizeHydrogens(tmpMolecule, HydrogenState.Minimal);
                 //might throw exceptions if the implicit hydrogen count is unset or kekulization is impossible
                 Kekulization.kekulize(tmpMolecule);
             } catch (Exception anException) {

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -44,6 +44,7 @@ import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.LonePairElectronChecker;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+import org.openscience.cdk.tools.manipulator.HydrogenState;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 import javax.vecmath.Point2d;
@@ -207,7 +208,8 @@ public final class ChemUtil {
         String tmpMolecularFormulaString = null;
         try {
             tmpAtomContainerClone = anAtomContainer.clone();
-            AtomContainerManipulator.suppressHydrogens(tmpAtomContainerClone);
+            //doc of MolecularFormulaManipulator.getMolecularFormula() says "The hydrogens must be implicit."
+            AtomContainerManipulator.normalizeHydrogens(tmpAtomContainerClone, HydrogenState.Minimal);
             IMolecularFormula tmpMolecularFormula = MolecularFormulaManipulator.getMolecularFormula(tmpAtomContainerClone);
             tmpMolecularFormulaString = MolecularFormulaManipulator.getString(tmpMolecularFormula);
         } catch (CloneNotSupportedException anException) {

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -44,7 +44,6 @@ import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.CDKHydrogenAdder;
 import org.openscience.cdk.tools.LonePairElectronChecker;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
-import org.openscience.cdk.tools.manipulator.HydrogenState;
 import org.openscience.cdk.tools.manipulator.MolecularFormulaManipulator;
 
 import javax.vecmath.Point2d;
@@ -204,18 +203,11 @@ public final class ChemUtil {
      * @author Samuel Behr
      */
     public static String generateMolecularFormula(IAtomContainer anAtomContainer) {
-        IAtomContainer tmpAtomContainerClone;
         String tmpMolecularFormulaString = null;
-        try {
-            tmpAtomContainerClone = anAtomContainer.clone();
-            //doc of MolecularFormulaManipulator.getMolecularFormula() says "The hydrogens must be implicit."
-            AtomContainerManipulator.normalizeHydrogens(tmpAtomContainerClone, HydrogenState.Minimal);
-            IMolecularFormula tmpMolecularFormula = MolecularFormulaManipulator.getMolecularFormula(tmpAtomContainerClone);
-            tmpMolecularFormulaString = MolecularFormulaManipulator.getString(tmpMolecularFormula);
-        } catch (CloneNotSupportedException anException) {
-            ChemUtil.LOGGER.log(Level.WARNING, String.format("%s molecule name: %s", anException.toString(),
-                    anAtomContainer.getProperty(Importer.MOLECULE_NAME_PROPERTY_KEY)), anException);
-        }
+        /* the doc of MolecularFormulaManipulator.getMolecularFormula() says "The hydrogens must be implicit." but the
+           CDK tests indicate that both implicit and explicit hydrogens are working fine */
+        IMolecularFormula tmpMolecularFormula = MolecularFormulaManipulator.getMolecularFormula(anAtomContainer);
+        tmpMolecularFormulaString = MolecularFormulaManipulator.getString(tmpMolecularFormula);
         return tmpMolecularFormulaString;
     }
 

--- a/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
+++ b/src/main/java/de/unijena/cheminf/mortar/model/util/ChemUtil.java
@@ -195,20 +195,17 @@ public final class ChemUtil {
     }
 
     /**
-     * Generates the molecular formula of a given atom container. If the molecular formula could not be generated, null
-     * is returned.
+     * Generates the molecular formula of a given atom container.
      *
      * @param anAtomContainer AtomContainer to generate the molecular formula of
      * @return String containing the molecular formula of the given atom container
-     * @author Samuel Behr
+     * @author Samuel Behr, Jonas Schaub
      */
     public static String generateMolecularFormula(IAtomContainer anAtomContainer) {
-        String tmpMolecularFormulaString = null;
         /* the doc of MolecularFormulaManipulator.getMolecularFormula() says "The hydrogens must be implicit." but the
            CDK tests indicate that both implicit and explicit hydrogens are working fine */
         IMolecularFormula tmpMolecularFormula = MolecularFormulaManipulator.getMolecularFormula(anAtomContainer);
-        tmpMolecularFormulaString = MolecularFormulaManipulator.getString(tmpMolecularFormula);
-        return tmpMolecularFormulaString;
+        return MolecularFormulaManipulator.getString(tmpMolecularFormula);
     }
 
     /**

--- a/src/main/resources/de/unijena/cheminf/mortar/descriptions/tools_description.xml
+++ b/src/main/resources/de/unijena/cheminf/mortar/descriptions/tools_description.xml
@@ -27,7 +27,7 @@
 <tools>
     <externalTool>
         <name>Chemistry Development Kit (CDK)</name>
-        <version>2.12-SNAPSHOT</version>
+        <version>2.12</version>
         <author>CDK Community</author>
         <license>LGPL v2.1</license>
     </externalTool>

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -41,6 +41,7 @@ import java.net.URL;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.regex.Pattern;
 
 /**
@@ -54,7 +55,7 @@ class ChemUtilTest {
      * CDK canonical SMILES and re-generate SMILES with stereo chemistry from the resulting atom containers.
      */
     @Test
-    public void testParseAndCreateUniqueSmilesRoundTrip() throws Exception {
+    void testParseAndCreateUniqueSmilesRoundTrip() throws Exception {
         String[] tmpSmilesCodes = new String[] {
                 "C/C=C(\\C)/C(=O)O[C@H]1C[C@@H]2C[C@@H](C[C@H]1N2C)OC(=O)/C=C(\\C)/C(=O)OCC", //CNP0315572.1
                 "C/C(=C\\C[C@@H]([C@@H](C)[C@H]1CC[C@@]2(C)C3=CC[C@H]4C(C)(C)[C@@H](CC[C@]4(C)C3=CC[C@]12C)O)OC(=O)C)/C(=O)O", //CNP0219624.2
@@ -88,9 +89,9 @@ class ChemUtilTest {
      * Test importing a MOL file containing a molecule with radicals and verifying that these are fixed correctly.
      */
     @Test
-    public void testFixRadicals() throws Exception {
+    void testFixRadicals() throws Exception {
         URL tmpURL = this.getClass().getResource("Mirabilin_B.mol");
-        File tmpResourceFile = Paths.get(tmpURL.toURI()).toFile();
+        File tmpResourceFile = Paths.get(Objects.requireNonNull(tmpURL).toURI()).toFile();
         MDLV2000Reader tmpReader = new MDLV2000Reader(new FileReader(tmpResourceFile));
         IAtomContainer tmpMolecule = tmpReader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         tmpReader.close();
@@ -104,7 +105,7 @@ class ChemUtilTest {
      * Makes sure that the Regex pattern in ChemUtil.fixAromaticNitrogenAndCreateSMILES() does not match 'n' in '[Sn]'.
      */
     @Test
-    public void testFixAromaticNitrogenAndCreateSMILESPattern() throws Exception {
+    void testFixAromaticNitrogenAndCreateSMILESPattern() throws Exception {
         //PubChem CID	16682804
         String tmpSmiles = "CC(=O)O[Sn](C1=CC=CC=C1)(C2=CC=CC=C2)C3=CC=CC=C3";
         Pattern tmpNPattern = Pattern.compile(ChemUtil.AROMATIC_N_REGEX);
@@ -115,7 +116,7 @@ class ChemUtilTest {
      * Tests fixing a molecule imported from an aromatic SMILES string that is missing an explicit H on an aromatic N.
      */
     @Test
-    public void testFixAromaticNitrogenAndCreateSMILES() throws Exception {
+    void testFixAromaticNitrogenAndCreateSMILES() throws Exception {
         //CHEBI:929 - one n needs to be fixed
         String tmpSmilesCode = "Nc1nc(N[C@@H]2O[C@H](COP(=O)(O)OP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]2O)c(N)c(=O)n1";
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
@@ -131,7 +132,7 @@ class ChemUtilTest {
      * Tests fixing a molecule imported from an aromatic SMILES string that is missing explicit Hs on multiple aromatic N.
      */
     @Test
-    public void testFixAromaticNitrogensAndCreateSMILES() throws Exception {
+    void testFixAromaticNitrogensAndCreateSMILES() throws Exception {
         //CHEBI:10048 - two n need to be fixed (without creating an uncharged(!) tetravalent N)
         String tmpSmilesCode = "O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1";
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
@@ -147,7 +148,7 @@ class ChemUtilTest {
      * Tests fixing a molecule imported from an aromatic SMILES string that is missing an explicit H on a charged aromatic N.
      */
     @Test
-    public void testFixAromaticChargedNitrogenAndCreateSMILES() throws Exception {
+    void testFixAromaticChargedNitrogenAndCreateSMILES() throws Exception {
         //CHEBI:20794 - one aromatic n is charged and therefore needs to be tetravalent in the solution
         String tmpSmilesCode = "C[n+]1cn([C@@H]2O[C@H](CO)[C@@H](O)[C@H]2O)c2nc(N)nc(=O)c21";
         SmilesParser tmpSmiPar = new SmilesParser(SilentChemObjectBuilder.getInstance());
@@ -165,7 +166,7 @@ class ChemUtilTest {
      * based on a bulk of ChEBI molecules with this issue.
      */
     @Test
-    public void testFixAromaticNitrogenAndCreateSMILESBulk() throws Exception {
+    void testFixAromaticNitrogenAndCreateSMILESBulk() throws Exception {
         String tmpChEBISmiles = """
                 CHEBI:10048	O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1
                 CHEBI:10049	O=c1nc(=O)c2ncn([C@@H]3O[C@H](COP(=O)(O)OP(=O)(O)OP(=O)(O)O)[C@@H](O)[C@H]3O)c2n1
@@ -202,6 +203,32 @@ class ChemUtilTest {
                 failMsg.append(tmpLine).append('\n');
             }
             Assertions.fail(failMsg.toString());
+        }
+    }
+    //
+    /**
+     * Tests the generation of molecular formulae on a few examples.
+     */
+    @Test
+    void testMolecularFormulaGeneration() throws Exception {
+        String[] tmpSmilesCodes = new String[]{
+                "C", // methane
+                "CCO", // ethanol
+                "c1ccccc1", // benzene
+                "CC(=O)O", // acetic acid
+                "N[C@@H](Cc1ccccc1)C(=O)O" // phenylalanine
+        };
+        String[] tmpExpectedFormulas = new String[]{
+                "CH4",
+                "C2H6O",
+                "C6H6",
+                "C2H4O2",
+                "C9H11NO2"
+        };
+        for (int i = 0; i < tmpSmilesCodes.length; i++) {
+            IAtomContainer tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmilesCodes[i], true, true);
+            String tmpFormula = ChemUtil.generateMolecularFormula(tmpMolecule);
+            Assertions.assertEquals(tmpExpectedFormulas[i], tmpFormula);
         }
     }
 }

--- a/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
+++ b/src/test/java/de/unijena/cheminf/mortar/model/util/ChemUtilTest.java
@@ -34,6 +34,7 @@ import org.openscience.cdk.smiles.SmiFlavor;
 import org.openscience.cdk.smiles.SmilesGenerator;
 import org.openscience.cdk.smiles.SmilesParser;
 import org.openscience.cdk.tools.manipulator.AtomContainerManipulator;
+import org.openscience.cdk.tools.manipulator.HydrogenState;
 
 import java.io.File;
 import java.io.FileReader;
@@ -91,7 +92,7 @@ class ChemUtilTest {
     @Test
     void testFixRadicals() throws Exception {
         URL tmpURL = this.getClass().getResource("Mirabilin_B.mol");
-        File tmpResourceFile = Paths.get(Objects.requireNonNull(tmpURL).toURI()).toFile();
+        File tmpResourceFile = Paths.get(Objects.requireNonNull(tmpURL, "Failed to fetch resource file Mirabilin_B.mol").toURI()).toFile();
         MDLV2000Reader tmpReader = new MDLV2000Reader(new FileReader(tmpResourceFile));
         IAtomContainer tmpMolecule = tmpReader.read(SilentChemObjectBuilder.getInstance().newAtomContainer());
         tmpReader.close();
@@ -228,6 +229,10 @@ class ChemUtilTest {
         for (int i = 0; i < tmpSmilesCodes.length; i++) {
             IAtomContainer tmpMolecule = ChemUtil.parseSmilesToAtomContainer(tmpSmilesCodes[i], true, true);
             String tmpFormula = ChemUtil.generateMolecularFormula(tmpMolecule);
+            Assertions.assertEquals(tmpExpectedFormulas[i], tmpFormula);
+            // make sure molecular formula generation is independent of hydrogen state
+            AtomContainerManipulator.normalizeHydrogens(tmpMolecule, HydrogenState.Explicit);
+            tmpFormula = ChemUtil.generateMolecularFormula(tmpMolecule);
             Assertions.assertEquals(tmpExpectedFormulas[i], tmpFormula);
         }
     }


### PR DESCRIPTION
closes #216 

This pull request updates the Chemistry Development Kit (CDK) dependency from a snapshot to a stable release and refactors hydrogen handling throughout the codebase to align with the new CDK API. It also simplifies molecular formula generation and enhances test coverage for this functionality.

Dependency update:

* Updated CDK dependency from version `2.12-SNAPSHOT` to stable `2.12` in `gradle/libs.versions.toml`, `README.md`, and `tools_description.xml`. [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R213) [[3]](diffhunk://#diff-441c83e8f76048b59755cd8219ab92c5730c0bc45797dde27c7cb2c1a73761e9L30-R30)

Hydrogen handling refactor:

* Replaced `AtomContainerManipulator.suppressHydrogens` with `AtomContainerManipulator.normalizeHydrogens` using `HydrogenState.Minimal` in `Importer.java` to reflect the new CDK API for hydrogen normalization.
* Added import for `HydrogenState` in both `Importer.java` and `ChemUtilTest.java`. [[1]](diffhunk://#diff-a4722b490363150b295a139b470ba9732cf8c8f12774be611d55940cf2238e5aR63) [[2]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dR37-R45)

Molecular formula generation improvements:

* Simplified `generateMolecularFormula` in `ChemUtil.java` by removing hydrogen suppression and clone logic, relying on CDK's handling of explicit and implicit hydrogens.
* Added a new test `testMolecularFormulaGeneration` in `ChemUtilTest.java` to verify formula generation is correct and independent of hydrogen state.

Test code modernization:

* Changed test method visibility from `public` to package-private and improved null checks in `ChemUtilTest.java`. [[1]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dL57-R59) [[2]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dL91-R95)

(References: [[1]](diffhunk://#diff-697f70cdd88ba88fe77eebda60c7e143f6ad1286bca75017421e93ad84fb87dfL4-R4) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L213-R213) [[3]](diffhunk://#diff-441c83e8f76048b59755cd8219ab92c5730c0bc45797dde27c7cb2c1a73761e9L30-R30) [[4]](diffhunk://#diff-a4722b490363150b295a139b470ba9732cf8c8f12774be611d55940cf2238e5aL604-R607) [[5]](diffhunk://#diff-16aab2cc28f51f72d015d950f44cd755f5ad898d3bff002745293b3fe3687501L198-R208) [[6]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dR209-R238) [[7]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dL57-R59) [[8]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dL91-R95) [[9]](diffhunk://#diff-a4722b490363150b295a139b470ba9732cf8c8f12774be611d55940cf2238e5aR63) [[10]](diffhunk://#diff-03ab4ddf7b6e815ed06f3a2319947e1f4670af937677f7f5b8fd005026350f4dR37-R45)