### PR TITLE
chore: updates dependencies CDK from 2.13-SNAPSHOT to 2.13 and cdk-scaffold from 2.8 to 2.13

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,7 +211,7 @@ will take care of it automatically.
 * JavaFX version 21.0.1
   * [Open JavaFX](https://openjfx.io)
   * GNU General Public License (GPL) Version 2
-* Chemistry Development Kit (CDK) version 2.13-SNAPSHOT
+* Chemistry Development Kit (CDK) version 2.13
     * [Chemistry Development Kit on GitHub](https://cdk.github.io/)
     * License: GNU Lesser General Public License 2.1
 * MolWURCS version 0.12.1

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,8 @@
 [versions]
 # libraries
 junit-version = "5.11.4"
-cdk-version = "2.13-SNAPSHOT"
-cdkScaffold-version = "2.8"
+cdk-version = "2.13"
+cdkScaffold-version = "2.13"
 javafx-version = "21.0.1"
 openpdf-version = "2.0.3"
 

--- a/src/main/resources/de/unijena/cheminf/mortar/descriptions/tools_description.xml
+++ b/src/main/resources/de/unijena/cheminf/mortar/descriptions/tools_description.xml
@@ -27,7 +27,7 @@
 <tools>
     <externalTool>
         <name>Chemistry Development Kit (CDK)</name>
-        <version>2.13-SNAPSHOT</version>
+        <version>2.13</version>
         <author>CDK Community</author>
         <license>LGPL v2.1</license>
     </externalTool>


### PR DESCRIPTION
This pull request updates the Chemistry Development Kit (CDK) dependency from a snapshot version to the official 2.13 release throughout the project. This ensures improved stability and consistency by using a finalized version of the library.

Dependency updates:

* Updated the CDK version from `2.13-SNAPSHOT` to `2.13` in `gradle/libs.versions.toml` and updated `cdkScaffold-version` to match the new release.
* Updated the CDK version reference in `README.md` to reflect the use of the official `2.13` release instead of the snapshot.
* Updated the CDK version in the external tool description in `tools_description.xml` to `2.13`.