### PR TITLE
fix: call show() only at the end of a constructor/method to have everything fully set up when it is shown

### DIFF
--- a/src/main/java/de/unijena/cheminf/mortar/controller/FragmentationSettingsViewController.java
+++ b/src/main/java/de/unijena/cheminf/mortar/controller/FragmentationSettingsViewController.java
@@ -113,7 +113,6 @@ public class FragmentationSettingsViewController {
         this.fragmentationSettingsViewStage.setScene(tmpScene);
         this.fragmentationSettingsViewStage.initModality(Modality.WINDOW_MODAL);
         this.fragmentationSettingsViewStage.initOwner(this.mainStage);
-        this.fragmentationSettingsViewStage.show();
         this.fragmentationSettingsViewStage.setTitle(Message.get("FragmentationSettingsView.title.text"));
         this.fragmentationSettingsViewStage.setMinHeight(GuiDefinitions.GUI_MAIN_VIEW_HEIGHT_VALUE);
         this.fragmentationSettingsViewStage.setMinWidth(GuiDefinitions.GUI_MAIN_VIEW_WIDTH_VALUE);
@@ -134,6 +133,7 @@ public class FragmentationSettingsViewController {
                 this.settingsView.getSelectionModel().select(tmpTab);
             }
         }
+        this.fragmentationSettingsViewStage.show();
     }
     //
     /**

--- a/src/main/java/de/unijena/cheminf/mortar/controller/MainViewController.java
+++ b/src/main/java/de/unijena/cheminf/mortar/controller/MainViewController.java
@@ -256,7 +256,6 @@ public class MainViewController {
         this.scene.getStylesheets().add(tmpStyleSheetURL);
         this.primaryStage.setTitle(Message.get("Title.text"));
         this.primaryStage.setScene(this.scene);
-        this.primaryStage.show();
         this.primaryStage.setMinHeight(GuiDefinitions.GUI_MAIN_VIEW_HEIGHT_VALUE);
         this.primaryStage.setMinWidth(GuiDefinitions.GUI_MAIN_VIEW_WIDTH_VALUE);
         String tmpIconURL = this.getClass().getClassLoader().getResource(
@@ -269,6 +268,7 @@ public class MainViewController {
         this.threadList = new CopyOnWriteArrayList<>();
         this.addListener();
         this.addFragmentationAlgorithmCheckMenuItems();
+        this.primaryStage.show();
     }
     //
     //<editor-fold desc="private methods" defaultstate="collapsed">

--- a/src/main/java/de/unijena/cheminf/mortar/controller/OverviewViewController.java
+++ b/src/main/java/de/unijena/cheminf/mortar/controller/OverviewViewController.java
@@ -1493,9 +1493,6 @@ public class OverviewViewController implements IViewToolController {
         tmpEnlargedStructureViewStage.getIcons().add(new Image(tmpIconURL));
         tmpEnlargedStructureViewStage.setMinHeight(OverviewViewController.ENLARGED_STRUCTURE_VIEW_MIN_HEIGHT_VALUE);
         tmpEnlargedStructureViewStage.setMinWidth(OverviewViewController.ENLARGED_STRUCTURE_VIEW_MIN_WIDTH_VALUE);
-        //
-        tmpEnlargedStructureViewStage.show();
-        //
         //generation of context menu for the options of copying the structure's image or SMILES String to the clipboard
         ContextMenu tmpContextMenu = this.generateContextMenuWithListeners(true);
         //
@@ -1552,6 +1549,7 @@ public class OverviewViewController implements IViewToolController {
             );
             tmpEnlargedStructureViewStage.close();
         }
+        tmpEnlargedStructureViewStage.show();
     }
     //</editor-fold>
 }

--- a/src/main/java/de/unijena/cheminf/mortar/controller/OverviewViewController.java
+++ b/src/main/java/de/unijena/cheminf/mortar/controller/OverviewViewController.java
@@ -1548,6 +1548,7 @@ public class OverviewViewController implements IViewToolController {
                     Message.get("OverviewView.enlargedStructureView.issueWithStructureDepiction.text")
             );
             tmpEnlargedStructureViewStage.close();
+            return;
         }
         tmpEnlargedStructureViewStage.show();
     }


### PR DESCRIPTION
The FragmentationSettingsView, MainView, and enlarged structure view of OverviewView were shown before being completely set up; this is corrected now by moving show() to the end of each method/constructor. Other instances -where showAndWait() is used- are not touched here to avoid conflicts with #226